### PR TITLE
feat(evm): add Permit2 support for all ERC-20 tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ generate-abi:
 	abigen --abi $(ROOT_DIR)/scheme/evm/eip3009/eip3009.abi \
 		--pkg eip3009 \
 		--out $(ROOT_DIR)/scheme/evm/eip3009/eip3009.go
+	abigen --abi $(ROOT_DIR)/scheme/evm/permit2/permit2.abi \
+		--pkg permit2 \
+		--type Permit2 \
+		--out $(ROOT_DIR)/scheme/evm/permit2/permit2.go

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -26,6 +26,7 @@ var (
 	to      string
 	amount  string
 	privkey string
+	method  string
 )
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 	fs.StringVarP(&to, "to", "T", "", "Recipient address")
 	fs.StringVarP(&amount, "amount", "A", "", "Amount to send")
 	fs.StringVarP(&privkey, "privkey", "P", "", "Sender private key")
+	fs.StringVarP(&method, "method", "m", "eip3009", "Payment method (eip3009 or permit2)")
 }
 
 func main() {
@@ -64,14 +66,30 @@ func run(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to decode private key")
 		}
-		evmPayload, err := evm.NewEVMPayload(network, token, from, to, amount, evm.NewRawPrivateSigner(priv))
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to create EVM payload")
+		signer := evm.NewRawPrivateSigner(priv)
+
+		var jsonPayload []byte
+		switch method {
+		case "permit2":
+			permit2Payload, err := evm.NewPermit2Payload(network, token, from, to, amount, signer)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create Permit2 payload")
+			}
+			jsonPayload, err = json.Marshal(permit2Payload)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to marshal Permit2 payload to JSON")
+			}
+		default: // "eip3009"
+			evmPayload, err := evm.NewEVMPayload(network, token, from, to, amount, signer)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to create EVM payload")
+			}
+			jsonPayload, err = json.Marshal(evmPayload)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to marshal EVM payload to JSON")
+			}
 		}
-		jsonPayload, err := json.Marshal(evmPayload)
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed to marshal EVM payload to JSON")
-		}
+
 		paymentPayload = &types.PaymentPayload{
 			X402Version: int(types.X402VersionV1),
 			Scheme:      scheme,

--- a/facilitator/evm.go
+++ b/facilitator/evm.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/gosuda/x402-facilitator/scheme/evm"
 	"github.com/gosuda/x402-facilitator/scheme/evm/eip3009"
+	"github.com/gosuda/x402-facilitator/scheme/evm/permit2"
 	"github.com/gosuda/x402-facilitator/types"
 )
 
@@ -74,6 +76,31 @@ func NewEVMFacilitator(network string, url string, privateKeyHex string) (*EVMFa
 	}, nil
 }
 
+// Verify detects the payload type and routes to the appropriate verification method.
+func (t *EVMFacilitator) Verify(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
+	if evm.IsPermit2PayloadJSON(payload.Payload) {
+		return t.verifyPermit2(ctx, payload, req)
+	}
+	return t.verifyEIP3009(ctx, payload, req)
+}
+
+// Settle detects the payload type and routes to the appropriate settlement method.
+func (t *EVMFacilitator) Settle(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
+	if evm.IsPermit2PayloadJSON(payload.Payload) {
+		return t.settlePermit2(ctx, payload, req)
+	}
+	return t.settleEIP3009(ctx, payload, req)
+}
+
+func (t *EVMFacilitator) Supported() []*types.SupportedKind {
+	return []*types.SupportedKind{
+		{
+			Scheme:  string(t.scheme),
+			Network: t.network,
+		},
+	}
+}
+
 // verification steps:
 //   - ✅ verify payload format
 //   - ✅ verify payload version
@@ -85,7 +112,7 @@ func NewEVMFacilitator(network string, url string, privateKeyHex string) (*EVMFa
 //   - ✅ verify value in payload is enough to cover paymentRequirements.maxAmountRequired
 //   - check min amount is above some threshold we think is reasonable for covering gas
 //   - verify resource is not already paid for (next version)
-func (t *EVMFacilitator) Verify(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
+func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
 	// Step 1: Payload format
 	var evmPayload evm.EVMPayload
 	if err := json.Unmarshal([]byte(payload.Payload), &evmPayload); err != nil {
@@ -190,7 +217,7 @@ func (t *EVMFacilitator) Verify(ctx context.Context, payload *types.PaymentPaylo
 	}, nil
 }
 
-func (t *EVMFacilitator) Settle(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
+func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
 	var evmPayload evm.EVMPayload
 	if err := json.Unmarshal([]byte(payload.Payload), &evmPayload); err != nil {
 		return &types.PaymentSettleResponse{
@@ -248,11 +275,250 @@ func (t *EVMFacilitator) Settle(ctx context.Context, payload *types.PaymentPaylo
 	}, nil
 }
 
-func (t *EVMFacilitator) Supported() []*types.SupportedKind {
-	return []*types.SupportedKind{
-		{
-			Scheme:  string(t.scheme),
-			Network: t.network,
-		},
+// Permit2 verification steps:
+//   - ✅ verify payload format
+//   - ✅ verify scheme matches
+//   - ✅ verify network matches
+//   - ✅ verify chain ID matches
+//   - ✅ verify spender is x402ExactPermit2Proxy
+//   - ✅ verify witness.to matches payTo
+//   - ✅ verify deadline not expired (with 6-second buffer)
+//   - ✅ verify validAfter not in the future
+//   - ✅ verify amount matches requirement
+//   - ✅ verify token matches requirement asset
+//   - ✅ verify EIP-712 signature
+//   - ✅ verify client has enough balance
+func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
+	// Step 1: Parse Permit2 payload
+	var permit2Payload evm.Permit2Payload
+	if err := json.Unmarshal([]byte(payload.Payload), &permit2Payload); err != nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
+		}, nil
 	}
+	auth := permit2Payload.Permit2Authorization
+	if auth == nil || auth.Nonce == nil || auth.Deadline == nil ||
+		auth.Permitted.Amount == nil || auth.Witness.ValidAfter == nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
+		}, nil
+	}
+
+	// Step 2: Scheme verification
+	if payload.Scheme != string(t.scheme) || req.Scheme != string(t.scheme) {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrIncompatibleScheme.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 3: Network verification
+	if payload.Network != t.network {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrNetworkMismatch.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+	chainID := evm.GetChainID(payload.Network)
+	if chainID == nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidNetwork.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+	if chainID.Cmp(t.networkID) != 0 {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrNetworkIDMismatch.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 4: Verify spender is x402ExactPermit2Proxy
+	if auth.Spender != evm.X402ExactPermit2ProxyAddress {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2InvalidSpender.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 5: Verify witness.to matches payTo
+	payTo := common.HexToAddress(req.PayTo)
+	if auth.Witness.To != payTo {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2RecipientMismatch.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 6: Deadline not expired (with 6-second buffer for block propagation)
+	now := time.Now().Unix()
+	if auth.Deadline.Cmp(big.NewInt(now+evm.Permit2DeadlineBuffer)) < 0 {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2DeadlineExpired.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 7: ValidAfter not in the future
+	if auth.Witness.ValidAfter.Cmp(big.NewInt(now)) > 0 {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2NotYetValid.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 8: Amount must exactly match requirement
+	reqAmount, ok := new(big.Int).SetString(req.MaxAmountRequired, 10)
+	if ok && auth.Permitted.Amount.Cmp(reqAmount) != 0 {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2AmountMismatch.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 9: Token matches requirement asset
+	tokenAddr := evm.GetTokenAddress(payload.Network, req.Asset)
+	if tokenAddr == (common.Address{}) {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2TokenMismatch.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+	if auth.Permitted.Token != tokenAddr {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2TokenMismatch.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 10: EIP-712 signature verification
+	sig, err := evm.ParseSignature(permit2Payload.Signature)
+	if err != nil {
+		return nil, err
+	}
+	digest := evm.HashPermit2(auth, chainID)
+	pubkey, err := evm.Ecrecover(digest, sig)
+	if err != nil {
+		return nil, err
+	}
+	if valid := evm.VerifySignature(pubkey, digest, sig[:64]); !valid {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2InvalidSignature.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// Step 11: Check ERC20 balance
+	// Bind to the token contract for balanceOf (not the proxy)
+	tokenContract, err := permit2.NewPermit2(auth.Permitted.Token, t.client)
+	if err != nil {
+		return nil, fmt.Errorf("token contract bind failed: %w", err)
+	}
+	balance, err := tokenContract.BalanceOf(&bind.CallOpts{Context: ctx}, auth.From)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get balance: %w", err)
+	}
+	if balance.Cmp(auth.Permitted.Amount) < 0 {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInsufficientBalance.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+
+	// ✅ All checks passed
+	return &types.PaymentVerifyResponse{
+		IsValid: true,
+		Payer:   auth.From.String(),
+	}, nil
+}
+
+func (t *EVMFacilitator) settlePermit2(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
+	var permit2Payload evm.Permit2Payload
+	if err := json.Unmarshal([]byte(payload.Payload), &permit2Payload); err != nil {
+		return &types.PaymentSettleResponse{
+			Success: false,
+			Error:   types.ErrInvalidPayloadFormat.Error(),
+		}, nil
+	}
+	auth := permit2Payload.Permit2Authorization
+	if auth == nil || auth.Nonce == nil || auth.Deadline == nil ||
+		auth.Permitted.Amount == nil || auth.Witness.ValidAfter == nil {
+		return &types.PaymentSettleResponse{
+			Success: false,
+			Error:   types.ErrInvalidPayloadFormat.Error(),
+		}, nil
+	}
+
+	networkID := evm.GetChainID(req.Network)
+	if networkID == nil {
+		return &types.PaymentSettleResponse{
+			Success: false,
+			Error:   types.ErrInvalidNetwork.Error(),
+		}, nil
+	}
+
+	// Bind to x402ExactPermit2Proxy contract
+	proxyContract, err := permit2.NewPermit2(evm.X402ExactPermit2ProxyAddress, t.client)
+	if err != nil {
+		return nil, fmt.Errorf("permit2 proxy contract bind failed: %w", err)
+	}
+
+	clientSig, err := evm.ParseSignature(permit2Payload.Signature)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build settle() arguments
+	// Note: abigen generates Struct0 for (address, uint256) tuples and Struct1 for the permit tuple.
+	// Struct0 is reused for both TokenPermissions (token, amount) and Witness (to, validAfter)
+	// because they share the same ABI shape (address, uint256).
+	permitArg := permit2.Struct1{
+		Permitted: permit2.Struct0{
+			Token:  auth.Permitted.Token,
+			Amount: auth.Permitted.Amount,
+		},
+		Nonce:    auth.Nonce,
+		Deadline: auth.Deadline,
+	}
+	// Witness fields map to Struct0: Token→To, Amount→ValidAfter
+	witnessArg := permit2.Struct0{
+		Token:  auth.Witness.To,
+		Amount: auth.Witness.ValidAfter,
+	}
+
+	tx, err := proxyContract.Settle(
+		&bind.TransactOpts{
+			Context: ctx,
+			Signer:  evm.ToGethSigner(t.signer, networkID),
+			From:    t.address,
+		},
+		permitArg,
+		auth.From,
+		witnessArg,
+		clientSig,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to settle permit2 payment: %w", err)
+	}
+
+	return &types.PaymentSettleResponse{
+		Success:   true,
+		TxHash:    tx.Hash().Hex(),
+		NetworkId: fmt.Sprintf("%d", networkID),
+	}, nil
 }

--- a/facilitator/evm.go
+++ b/facilitator/evm.go
@@ -379,7 +379,14 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 
 	// Step 8: Amount must exactly match requirement
 	reqAmount, ok := new(big.Int).SetString(req.MaxAmountRequired, 10)
-	if ok && auth.Permitted.Amount.Cmp(reqAmount) != 0 {
+	if !ok {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2AmountMismatch.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+	if auth.Permitted.Amount.Cmp(reqAmount) != 0 {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrPermit2AmountMismatch.Error(),

--- a/facilitator/evm_test.go
+++ b/facilitator/evm_test.go
@@ -81,3 +81,23 @@ func TestEVMSettle(t *testing.T) {
 	require.NoError(t, err)
 	fmt.Println(string(jsonRes))
 }
+
+func TestPayloadDetection(t *testing.T) {
+	t.Run("detects EIP3009 payload", func(t *testing.T) {
+		eip3009Json := []byte(`{"signature":"0xabc","authorization":{"from":"0x1234"}}`)
+		require.False(t, evm.IsPermit2PayloadJSON(eip3009Json))
+	})
+
+	t.Run("detects Permit2 payload", func(t *testing.T) {
+		permit2Json := []byte(`{"signature":"0xabc","permit2Authorization":{"from":"0x1234"}}`)
+		require.True(t, evm.IsPermit2PayloadJSON(permit2Json))
+	})
+
+	t.Run("returns false for invalid JSON", func(t *testing.T) {
+		require.False(t, evm.IsPermit2PayloadJSON([]byte(`{invalid`)))
+	})
+
+	t.Run("returns false for empty payload", func(t *testing.T) {
+		require.False(t, evm.IsPermit2PayloadJSON([]byte(`{}`)))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.2
 
 require (
 	github.com/blocto/solana-go-sdk v1.30.0
-	github.com/coinbase/x402/go v0.0.0-20260131002651-d9c7ed559bbe
+	github.com/coinbase/x402/go v0.0.0-20260318010130-6a90fe93c57f
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/ethereum/go-ethereum v1.16.8
 	github.com/knadh/koanf/parsers/toml v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwP
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
-github.com/coinbase/x402/go v0.0.0-20260131002651-d9c7ed559bbe h1:yuUbC03+ilLC1FB2RMnEuHnyS/W2TMyqzfUAZ+O/A+w=
-github.com/coinbase/x402/go v0.0.0-20260131002651-d9c7ed559bbe/go.mod h1:iNI3Kf6WZGnlV89JxKPIt2pH4qep/0e5sioekycurcQ=
+github.com/coinbase/x402/go v0.0.0-20260318010130-6a90fe93c57f h1:VmXakcNxw0yFZYbVlqvyo0AZrOEzZ1hN3pNw1wIwdL8=
+github.com/coinbase/x402/go v0.0.0-20260318010130-6a90fe93c57f/go.mod h1:Igc3tBTV0bx8sK0s2zi0qNLO3M+jloH9nMuZx6t3r1Y=
 github.com/consensys/gnark-crypto v0.18.1 h1:RyLV6UhPRoYYzaFnPQA4qK3DyuDgkTgskDdoGqFt3fI=
 github.com/consensys/gnark-crypto v0.18.1/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -50,6 +50,15 @@ type (
 	// ExactPermit2Payload represents the Permit2 payment payload
 	ExactPermit2Payload = evm.ExactPermit2Payload
 
+	// Permit2Authorization represents the Permit2 authorization parameters
+	Permit2Authorization = evm.Permit2Authorization
+
+	// Permit2TokenPermissions represents token permissions for Permit2
+	Permit2TokenPermissions = evm.Permit2TokenPermissions
+
+	// Permit2Witness represents witness data for Permit2
+	Permit2Witness = evm.Permit2Witness
+
 	// FacilitatorEvmSigner is the interface that must be implemented
 	// to connect the SDK to actual EVM RPC endpoints
 	FacilitatorEvmSigner = evm.FacilitatorEvmSigner

--- a/scheme/evm/chaincfg.go
+++ b/scheme/evm/chaincfg.go
@@ -2,9 +2,30 @@ package evm
 
 import (
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 )
+
+var (
+	// Permit2 canonical contract address (same on all EVM chains via CREATE2)
+	Permit2Address = common.HexToAddress("0x000000000022D473030F116dDEE9F6B43aC78BA3")
+
+	// x402 exact payment proxy for Permit2
+	X402ExactPermit2ProxyAddress = common.HexToAddress("0x402085c248EeA27D92E8b30b2C58ed07f9E20001")
+)
+
+const Permit2DeadlineBuffer int64 = 6
+
+func GetTokenAddress(chain, asset string) common.Address {
+	if strings.HasPrefix(asset, "0x") && len(asset) == 42 {
+		return common.HexToAddress(asset)
+	}
+	if domainConfig := GetDomainConfig(chain, asset); domainConfig != nil {
+		return domainConfig.VerifyingContract
+	}
+	return common.Address{}
+}
 
 func GetChainName(chainID *big.Int) string {
 	if chainID == nil {

--- a/scheme/evm/permit2/permit2.abi
+++ b/scheme/evm/permit2/permit2.abi
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "settle",
+    "type": "function",
+    "inputs": [
+      {
+        "name": "permit",
+        "type": "tuple",
+        "components": [
+          {
+            "name": "permitted",
+            "type": "tuple",
+            "components": [
+              { "name": "token", "type": "address" },
+              { "name": "amount", "type": "uint256" }
+            ]
+          },
+          { "name": "nonce", "type": "uint256" },
+          { "name": "deadline", "type": "uint256" }
+        ]
+      },
+      { "name": "owner", "type": "address" },
+      {
+        "name": "witness",
+        "type": "tuple",
+        "components": [
+          { "name": "to", "type": "address" },
+          { "name": "validAfter", "type": "uint256" }
+        ]
+      },
+      { "name": "signature", "type": "bytes" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "name": "balanceOf",
+    "type": "function",
+    "inputs": [
+      { "name": "account", "type": "address" }
+    ],
+    "outputs": [
+      { "name": "balance", "type": "uint256" }
+    ],
+    "stateMutability": "view"
+  }
+]

--- a/scheme/evm/permit2/permit2.go
+++ b/scheme/evm/permit2/permit2.go
@@ -1,0 +1,246 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package permit2
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// Struct1 is an auto generated low-level Go binding around an user-defined struct.
+type Struct1 struct {
+	Permitted Struct0
+	Nonce     *big.Int
+	Deadline  *big.Int
+}
+
+// Struct0 is an auto generated low-level Go binding around an user-defined struct.
+type Struct0 struct {
+	Token  common.Address
+	Amount *big.Int
+}
+
+// Permit2MetaData contains all meta data concerning the Permit2 contract.
+var Permit2MetaData = &bind.MetaData{
+	ABI: "[{\"name\":\"settle\",\"type\":\"function\",\"inputs\":[{\"name\":\"permit\",\"type\":\"tuple\",\"components\":[{\"name\":\"permitted\",\"type\":\"tuple\",\"components\":[{\"name\":\"token\",\"type\":\"address\"},{\"name\":\"amount\",\"type\":\"uint256\"}]},{\"name\":\"nonce\",\"type\":\"uint256\"},{\"name\":\"deadline\",\"type\":\"uint256\"}]},{\"name\":\"owner\",\"type\":\"address\"},{\"name\":\"witness\",\"type\":\"tuple\",\"components\":[{\"name\":\"to\",\"type\":\"address\"},{\"name\":\"validAfter\",\"type\":\"uint256\"}]},{\"name\":\"signature\",\"type\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"name\":\"balanceOf\",\"type\":\"function\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\"}],\"outputs\":[{\"name\":\"balance\",\"type\":\"uint256\"}],\"stateMutability\":\"view\"}]",
+}
+
+// Permit2ABI is the input ABI used to generate the binding from.
+// Deprecated: Use Permit2MetaData.ABI instead.
+var Permit2ABI = Permit2MetaData.ABI
+
+// Permit2 is an auto generated Go binding around an Ethereum contract.
+type Permit2 struct {
+	Permit2Caller     // Read-only binding to the contract
+	Permit2Transactor // Write-only binding to the contract
+	Permit2Filterer   // Log filterer for contract events
+}
+
+// Permit2Caller is an auto generated read-only Go binding around an Ethereum contract.
+type Permit2Caller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// Permit2Transactor is an auto generated write-only Go binding around an Ethereum contract.
+type Permit2Transactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// Permit2Filterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type Permit2Filterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// Permit2Session is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type Permit2Session struct {
+	Contract     *Permit2          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// Permit2CallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type Permit2CallerSession struct {
+	Contract *Permit2Caller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// Permit2TransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type Permit2TransactorSession struct {
+	Contract     *Permit2Transactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// Permit2Raw is an auto generated low-level Go binding around an Ethereum contract.
+type Permit2Raw struct {
+	Contract *Permit2 // Generic contract binding to access the raw methods on
+}
+
+// Permit2CallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type Permit2CallerRaw struct {
+	Contract *Permit2Caller // Generic read-only contract binding to access the raw methods on
+}
+
+// Permit2TransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type Permit2TransactorRaw struct {
+	Contract *Permit2Transactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewPermit2 creates a new instance of Permit2, bound to a specific deployed contract.
+func NewPermit2(address common.Address, backend bind.ContractBackend) (*Permit2, error) {
+	contract, err := bindPermit2(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Permit2{Permit2Caller: Permit2Caller{contract: contract}, Permit2Transactor: Permit2Transactor{contract: contract}, Permit2Filterer: Permit2Filterer{contract: contract}}, nil
+}
+
+// NewPermit2Caller creates a new read-only instance of Permit2, bound to a specific deployed contract.
+func NewPermit2Caller(address common.Address, caller bind.ContractCaller) (*Permit2Caller, error) {
+	contract, err := bindPermit2(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &Permit2Caller{contract: contract}, nil
+}
+
+// NewPermit2Transactor creates a new write-only instance of Permit2, bound to a specific deployed contract.
+func NewPermit2Transactor(address common.Address, transactor bind.ContractTransactor) (*Permit2Transactor, error) {
+	contract, err := bindPermit2(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &Permit2Transactor{contract: contract}, nil
+}
+
+// NewPermit2Filterer creates a new log filterer instance of Permit2, bound to a specific deployed contract.
+func NewPermit2Filterer(address common.Address, filterer bind.ContractFilterer) (*Permit2Filterer, error) {
+	contract, err := bindPermit2(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &Permit2Filterer{contract: contract}, nil
+}
+
+// bindPermit2 binds a generic wrapper to an already deployed contract.
+func bindPermit2(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := Permit2MetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Permit2 *Permit2Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Permit2.Contract.Permit2Caller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Permit2 *Permit2Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Permit2.Contract.Permit2Transactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Permit2 *Permit2Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Permit2.Contract.Permit2Transactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Permit2 *Permit2CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Permit2.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Permit2 *Permit2TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Permit2.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Permit2 *Permit2TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Permit2.Contract.contract.Transact(opts, method, params...)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256 balance)
+func (_Permit2 *Permit2Caller) BalanceOf(opts *bind.CallOpts, account common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _Permit2.contract.Call(opts, &out, "balanceOf", account)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256 balance)
+func (_Permit2 *Permit2Session) BalanceOf(account common.Address) (*big.Int, error) {
+	return _Permit2.Contract.BalanceOf(&_Permit2.CallOpts, account)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256 balance)
+func (_Permit2 *Permit2CallerSession) BalanceOf(account common.Address) (*big.Int, error) {
+	return _Permit2.Contract.BalanceOf(&_Permit2.CallOpts, account)
+}
+
+// Settle is a paid mutator transaction binding the contract method 0x13cd3b53.
+//
+// Solidity: function settle(((address,uint256),uint256,uint256) permit, address owner, (address,uint256) witness, bytes signature) returns()
+func (_Permit2 *Permit2Transactor) Settle(opts *bind.TransactOpts, permit Struct1, owner common.Address, witness Struct0, signature []byte) (*types.Transaction, error) {
+	return _Permit2.contract.Transact(opts, "settle", permit, owner, witness, signature)
+}
+
+// Settle is a paid mutator transaction binding the contract method 0x13cd3b53.
+//
+// Solidity: function settle(((address,uint256),uint256,uint256) permit, address owner, (address,uint256) witness, bytes signature) returns()
+func (_Permit2 *Permit2Session) Settle(permit Struct1, owner common.Address, witness Struct0, signature []byte) (*types.Transaction, error) {
+	return _Permit2.Contract.Settle(&_Permit2.TransactOpts, permit, owner, witness, signature)
+}
+
+// Settle is a paid mutator transaction binding the contract method 0x13cd3b53.
+//
+// Solidity: function settle(((address,uint256),uint256,uint256) permit, address owner, (address,uint256) witness, bytes signature) returns()
+func (_Permit2 *Permit2TransactorSession) Settle(permit Struct1, owner common.Address, witness Struct0, signature []byte) (*types.Transaction, error) {
+	return _Permit2.Contract.Settle(&_Permit2.TransactOpts, permit, owner, witness, signature)
+}

--- a/scheme/evm/signer.go
+++ b/scheme/evm/signer.go
@@ -59,3 +59,27 @@ func HashEip3009(auth *Authorization, domain *DomainConfig) []byte {
 		append(prefix, append(domainSeparator, messageHash...)...),
 	)
 }
+
+func SignPermit2(auth *Permit2Authorization, chainID *big.Int, signer types.Signer) (string, error) {
+	sig, err := signer(HashPermit2(auth, chainID))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(sig), nil
+}
+
+func HashPermit2(auth *Permit2Authorization, chainID *big.Int) []byte {
+	domain := Permit2DomainConfig{
+		Name:              "Permit2",
+		ChainID:           chainID,
+		VerifyingContract: Permit2Address,
+	}
+	domainSeparator := domain.ToMessageHash()
+	messageHash := auth.ToMessageHash()
+
+	// Final EIP-712 hash
+	var prefix = []byte{0x19, 0x01}
+	return Keccak256(
+		append(prefix, append(domainSeparator, messageHash...)...),
+	)
+}

--- a/scheme/evm/signer_test.go
+++ b/scheme/evm/signer_test.go
@@ -2,9 +2,12 @@ package evm
 
 import (
 	"encoding/hex"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,4 +58,70 @@ func TestPayloadSignVerify(t *testing.T) {
 	// Verify the signature
 	valid := VerifySignature(pubkey, message, signature[:64])
 	require.True(t, valid, "signature verification failed")
+}
+
+func TestPermit2SignVerify(t *testing.T) {
+	privKey, err := secp256k1.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	signer := NewRawPrivateSigner(privKey.Serialize())
+
+	auth := &Permit2Authorization{
+		From:     common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+		Spender:  X402ExactPermit2ProxyAddress,
+		Nonce:    big.NewInt(1),
+		Deadline: big.NewInt(time.Now().Unix() + 3600),
+		Permitted: Permit2TokenPermissions{
+			Token:  common.HexToAddress("0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
+			Amount: big.NewInt(1000000),
+		},
+		Witness: Permit2Witness{
+			To:         common.HexToAddress("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+			ValidAfter: big.NewInt(0),
+		},
+	}
+
+	chainID := big.NewInt(84532) // base-sepolia
+
+	sigHex, err := SignPermit2(auth, chainID, signer)
+	require.NoError(t, err)
+
+	digest := HashPermit2(auth, chainID)
+	sig, err := hex.DecodeString(sigHex)
+	require.NoError(t, err)
+
+	pubkey, err := Ecrecover(digest, sig)
+	require.NoError(t, err)
+
+	valid := VerifySignature(pubkey, digest, sig[:64])
+	require.True(t, valid, "permit2 signature verification failed")
+}
+
+func TestPermit2PayloadSignVerify(t *testing.T) {
+	privKey, err := secp256k1.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	signer := NewRawPrivateSigner(privKey.Serialize())
+
+	chain := "base-sepolia"
+	token := "USDC"
+
+	payload, err := NewPermit2Payload(chain, token,
+		"0x1234567890abcdef1234567890abcdef12345678", "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd", "1000000", signer)
+	require.NoError(t, err)
+	require.NotNil(t, payload.Permit2Authorization)
+
+	auth := payload.Permit2Authorization
+	chainID := GetChainID(chain)
+	require.NotNil(t, chainID)
+
+	digest := HashPermit2(auth, chainID)
+	sig, err := hex.DecodeString(payload.Signature)
+	require.NoError(t, err)
+
+	pubkey, err := Ecrecover(digest, sig)
+	require.NoError(t, err)
+
+	valid := VerifySignature(pubkey, digest, sig[:64])
+	require.True(t, valid, "permit2 payload signature verification failed")
 }

--- a/scheme/evm/types.go
+++ b/scheme/evm/types.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -178,6 +179,152 @@ func ParseAddress(hexStr string) (common.Address, error) {
 	}
 	copy(a[:], b)
 	return a, nil
+}
+
+// Permit2TokenPermissions represents the permitted token and amount for Permit2.
+type Permit2TokenPermissions struct {
+	Token  common.Address `json:"token"`
+	Amount *big.Int       `json:"amount"`
+}
+
+// Permit2Witness represents witness data for x402ExactPermit2Proxy.
+type Permit2Witness struct {
+	To         common.Address `json:"to"`
+	ValidAfter *big.Int       `json:"validAfter"`
+}
+
+// Permit2Authorization represents the PermitWitnessTransferFrom parameters.
+type Permit2Authorization struct {
+	From      common.Address          `json:"from"`
+	Permitted Permit2TokenPermissions `json:"permitted"`
+	Spender   common.Address          `json:"spender"`
+	Nonce     *big.Int                `json:"nonce"`
+	Deadline  *big.Int                `json:"deadline"`
+	Witness   Permit2Witness          `json:"witness"`
+}
+
+// Permit2Payload represents a Permit2 payment payload.
+type Permit2Payload struct {
+	Signature            string                `json:"signature"`
+	Permit2Authorization *Permit2Authorization `json:"permit2Authorization"`
+}
+
+var (
+	// Permit2 EIP-712 type hashes
+	Permit2WitnessTypeHash                   = Keccak256([]byte("Witness(address to,uint256 validAfter)"))
+	Permit2TokenPermissionsTypeHash          = Keccak256([]byte("TokenPermissions(address token,uint256 amount)"))
+	Permit2PermitWitnessTransferFromTypeHash = Keccak256([]byte("PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)TokenPermissions(address token,uint256 amount)Witness(address to,uint256 validAfter)"))
+
+	// Permit2 EIP-712 domain separator (no version field)
+	Permit2DomainTypeHash = Keccak256([]byte("EIP712Domain(string name,uint256 chainId,address verifyingContract)"))
+)
+
+func (a Permit2Authorization) ToMessageHash() []byte {
+	permittedHash := Keccak256(bytes.Join([][]byte{
+		Permit2TokenPermissionsTypeHash,
+		padAddress(a.Permitted.Token),
+		padBigInt(a.Permitted.Amount),
+	}, nil))
+	witnessHash := Keccak256(bytes.Join([][]byte{
+		Permit2WitnessTypeHash,
+		padAddress(a.Witness.To),
+		padBigInt(a.Witness.ValidAfter),
+	}, nil))
+	encoded := bytes.Join([][]byte{
+		Permit2PermitWitnessTransferFromTypeHash,
+		permittedHash,
+		padAddress(a.Spender),
+		padBigInt(a.Nonce),
+		padBigInt(a.Deadline),
+		witnessHash,
+	}, nil)
+	return Keccak256(encoded)
+}
+
+// Permit2DomainConfig represents the domain configuration for Permit2
+// EIP-712 typed data messages (no version field)
+type Permit2DomainConfig struct {
+	Name              string
+	ChainID           *big.Int
+	VerifyingContract common.Address
+}
+
+func (d Permit2DomainConfig) ToMessageHash() []byte {
+	nameHash := Keccak256([]byte(d.Name))
+	chainID := padBigInt(d.ChainID)
+	contract := padAddress(d.VerifyingContract)
+
+	return Keccak256(
+		Permit2DomainTypeHash,
+		nameHash,
+		chainID,
+		contract,
+	)
+}
+
+func NewPermit2Payload(chain, token, from, to string, value string, signer types.Signer) (*Permit2Payload, error) {
+	valueBig, ok := big.NewInt(0).SetString(value, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid value: %s", value)
+	}
+
+	tokenAddr := GetTokenAddress(chain, token)
+	if tokenAddr == (common.Address{}) {
+		return nil, fmt.Errorf("token address not found for chain %s and token %s", chain, token)
+	}
+
+	chainID := GetChainID(chain)
+	if chainID == nil {
+		return nil, fmt.Errorf("unsupported chain: %s", chain)
+	}
+
+	now := time.Now().Unix()
+	nonce := GeneratePermit2Nonce()
+
+	auth := &Permit2Authorization{
+		From: common.HexToAddress(from),
+		Permitted: Permit2TokenPermissions{
+			Token:  tokenAddr,
+			Amount: valueBig,
+		},
+		Spender:  X402ExactPermit2ProxyAddress,
+		Nonce:    nonce,
+		Deadline: big.NewInt(now + 3600), // 1 hour
+		Witness: Permit2Witness{
+			To:         common.HexToAddress(to),
+			ValidAfter: big.NewInt(0),
+		},
+	}
+
+	signature, err := SignPermit2(auth, chainID, signer)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Permit2Payload{
+		Signature:            signature,
+		Permit2Authorization: auth,
+	}, nil
+}
+
+// GeneratePermit2Nonce generates a random uint256 nonce for Permit2.
+func GeneratePermit2Nonce() *big.Int {
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	return new(big.Int).SetBytes(nonce)
+}
+
+// IsPermit2PayloadJSON checks if a JSON payload contains permit2Authorization.
+func IsPermit2PayloadJSON(data json.RawMessage) bool {
+	var probe struct {
+		Permit2Authorization json.RawMessage `json:"permit2Authorization"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	// Reject null, empty, or missing permit2Authorization
+	return len(probe.Permit2Authorization) > 0 &&
+		string(probe.Permit2Authorization) != "null"
 }
 
 func ParseSignature(sigHex string) ([]byte, error) {

--- a/types/error.go
+++ b/types/error.go
@@ -12,4 +12,13 @@ var (
 	ErrInvalidToken         = errors.New("invalid_token")
 	ErrTokenMismatch        = errors.New("token_mismatch")
 	ErrInsufficientBalance  = errors.New("insufficient_balance")
+
+	// Permit2 errors
+	ErrPermit2InvalidSpender    = errors.New("permit2_invalid_spender")
+	ErrPermit2RecipientMismatch = errors.New("permit2_recipient_mismatch")
+	ErrPermit2DeadlineExpired   = errors.New("permit2_deadline_expired")
+	ErrPermit2NotYetValid       = errors.New("permit2_not_yet_valid")
+	ErrPermit2AmountMismatch    = errors.New("permit2_amount_mismatch")
+	ErrPermit2TokenMismatch     = errors.New("permit2_token_mismatch")
+	ErrPermit2InvalidSignature  = errors.New("permit2_invalid_signature")
 )


### PR DESCRIPTION
## Summary

  - Add Permit2 (Uniswap) support alongside existing EIP-3009, enabling payments with any ERC-20 token
  - Payload type is auto-detected, so existing EIP-3009 flows are fully preserved
  - Follows existing project patterns: custom Go implementation with SDK used only as reference

## What's included

**Types & Crypto** (`scheme/evm/`)
  - Permit2 types with EIP-712 type hashes and domain config (no version field per spec)
  - `SignPermit2` / `HashPermit2` mirroring existing `SignEip3009` / `HashEip3009`
  - `IsPermit2PayloadJSON` for payload type detection

  **Contract Bindings** (`scheme/evm/permit2/`)
  - ABI + abigen-generated binding for `x402ExactPermit2Proxy.settle()` and ERC-20 `balanceOf()`

  **Facilitator Logic** (`facilitator/evm.go`)
  - `Verify` / `Settle` auto-route to EIP-3009 or Permit2 based on payload
  - 12-step Permit2 verification: spender, recipient, deadline (6s buffer), validAfter, exact amount match, token, EIP-712 signature, balance
  - Nil-guard validation on `*big.Int` fields after JSON unmarshal

  **Client & Config**
  - `--method permit2` flag on `x402-client`
  - `GetTokenAddress()` resolves both token symbols and direct contract addresses
  - SDK updated to `v0.0.0-20260318` (latest Permit2 spec)

  ## Tests

  - `TestPermit2SignVerify` — sign + ecrecover + verify roundtrip
  - `TestPermit2PayloadSignVerify` — full payload creation + signature verification
  - `TestPayloadDetection` — EIP-3009 vs Permit2 vs invalid/empty/null detection
  - All existing tests pass unchanged

  ## Test plan

  - [ ] `go build ./...`
  - [ ] `go test ./scheme/evm/ -run TestPermit2`
  - [ ] `go test ./facilitator/ -run TestPayloadDetection`
  - [ ] `go test ./internal/sdk/`
  - [ ] `make build`