### PR TITLE
fix(evm): verify recovered signer address matches claimed sender

### DIFF
--- a/facilitator/evm.go
+++ b/facilitator/evm.go
@@ -168,12 +168,19 @@ func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.Payme
 	if err != nil {
 		return nil, err
 	}
-	digest := evmPayload.Authorization.ToMessageHash()
+	digest := evm.HashEip3009(evmPayload.Authorization, domainConfig)
 	pubkey, err := evm.Ecrecover(digest, sig)
 	if err != nil {
 		return nil, err
 	}
 	if valid := evm.VerifySignature(pubkey, digest, sig[:64]); !valid {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidSignature.Error(),
+			Payer:         evmPayload.Authorization.From.String(),
+		}, nil
+	}
+	if evm.PubkeyToAddress(pubkey) != evmPayload.Authorization.From {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrInvalidSignature.Error(),
@@ -422,6 +429,13 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 		return nil, err
 	}
 	if valid := evm.VerifySignature(pubkey, digest, sig[:64]); !valid {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrPermit2InvalidSignature.Error(),
+			Payer:         auth.From.String(),
+		}, nil
+	}
+	if evm.PubkeyToAddress(pubkey) != auth.From {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrPermit2InvalidSignature.Error(),

--- a/scheme/evm/crypto.go
+++ b/scheme/evm/crypto.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	decred_ecdsa "github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // SignatureLength indicates the byte length required to carry a signature with recovery id.
@@ -69,6 +70,11 @@ func Sign(hash []byte, prv *ecdsa.PrivateKey) ([]byte, error) {
 	copy(sig, sig[1:])
 	sig[RecoveryIDOffset] = v
 	return sig, nil
+}
+
+// PubkeyToAddress derives an Ethereum address from an uncompressed public key.
+func PubkeyToAddress(pubkey []byte) common.Address {
+	return common.BytesToAddress(Keccak256(pubkey[1:])[12:])
 }
 
 // VerifySignature checks that the given public key created signature over hash.


### PR DESCRIPTION
## Summary

  - Verify that the address recovered from the EIP-712 signature matches the claimed `from` address in both EIP-3009 and Permit2 verification paths
  - Fix EIP-3009 verification to use the full EIP-712 hash (domain separator + struct hash) instead of struct hash only

  ## Changes

  - `scheme/evm/crypto.go`: Add `PubkeyToAddress()` helper to derive address from uncompressed public key
  - `facilitator/evm.go`: Add signer address check after `Ecrecover` in both `verifyEIP3009` and `verifyPermit2`
  - `facilitator/evm.go`: Use `HashEip3009()` instead of `ToMessageHash()` for correct EIP-712 digest

  ## Test plan

  - [ ] `go build ./...`
  - [ ] `go test ./scheme/evm/ -v`
  - [ ] `go test ./facilitator/ -v`