### PR TITLE
feat(v2): migrate facilitator to x402 v2 wire spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,22 @@
 - Docker
 - Docker Compose
 
-## Support Schemes
-| Scheme     | Status           | Description                   |
-|------------|------------------|-------------------------------|
-| EVM       | ✅ Supported      | Ethereum and EVM chains       |
-| Solana    | 🚧 Planned        |                               |
-| Sui       | 🚧 Planned        |                               |
-| Tron      | 🚧 Planned        |                               |
+## Supported schemes × networks
+
+x402 v2 treats the payment **scheme** (the on-chain protocol used to move
+funds) and the **network** (which chain that protocol runs on) as two
+independent axes. This facilitator currently supports:
+
+| Scheme  | `eip155:*` (EVM) | `solana:*` | `sui:*` | `tron:*` |
+|---------|:----------------:|:----------:|:-------:|:--------:|
+| `exact` |        ✅        |     🚧     |   🚧    |    🚧    |
+
+Networks are specified in [CAIP-2](https://chainagnostic.org/CAIPs/caip-2)
+format (e.g. `eip155:84532` for Base Sepolia, `eip155:8453` for Base
+mainnet, `eip155:42161` for Arbitrum One). The `exact` scheme supports
+both EIP-3009 `transferWithAuthorization` and Permit2
+`PermitWitnessTransferFrom` payloads on EVM chains; see the `--method`
+flag on `x402-client` to pick between them.
 
 ## How to run
 
@@ -31,15 +40,28 @@ docker compose up
 
 #### 2. Configuration
 x402-facilitator is configured via `config.toml`.
-```
+```toml
 # Port for HTTP server (default: 9090)
 port = 9090
 
-# Blockchain access configuration
-scheme = "evm"                   # Supported: "evm", "solana", "sui", "tron"
-network = "base-sepolia"         # Network or chain name
-url = "https://sepolia.base.org" # RPC endpoint or node URL
-privateKey = ""                  # Private key for fee payer (hex string)
+# Payment protocol scheme. Currently only "exact" is supported; the
+# value is the x402 v2 scheme identifier, not a chain name.
+scheme = "exact"
+
+# Network in CAIP-2 format. Examples:
+#   eip155:84532  — Base Sepolia
+#   eip155:8453   — Base mainnet
+#   eip155:42161  — Arbitrum One
+network = "eip155:84532"
+
+# RPC endpoint the facilitator uses to verify and broadcast
+# transactions on the configured network.
+url = "https://sepolia.base.org"
+
+# Private key of the facilitator's fee payer (hex, no 0x prefix).
+# Leave empty in the repo; inject via your deployment's secret
+# management.
+privateKey = ""
 ```
 
 #### 3. Api Specification
@@ -57,15 +79,16 @@ Flags:
   -A, --amount string    Amount to send
   -F, --from string      Sender address
   -h, --help             help for x402-client
-  -n, --network string   Blockchain network to use (default "base-sepolia")
+  -m, --method string    Payment method (eip3009 or permit2) (default "eip3009")
+  -n, --network string   CAIP-2 network to pay on (default "eip155:84532")
   -P, --privkey string   Sender private key
-  -s, --scheme string    Scheme to use (default "evm")
+  -s, --scheme string    Payment scheme to use (default "exact")
   -T, --to string        Recipient address
   -t, --token string     token contract for sending (default "USDC")
   -u, --url string       Base URL of the facilitator server (default "http://localhost:9090")
 
 Example:
-  x402-client -n base-sepolia -s evm -t USDC -F {0xYourSenderAddress} -T {0xRecipientAddress} -P {YourPrivateKey} -A 1000
+  x402-client -n eip155:84532 -s exact -t USDC -F {0xYourSenderAddress} -T {0xRecipientAddress} -P {YourPrivateKey} -A 1000
 ```
 
 

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -29,19 +29,20 @@ func NewClient(baseURL string) (*Client, error) {
 	}, nil
 }
 
-// Supported fetches the list of supported schemes.
-func (c *Client) Supported(ctx context.Context) ([]types.SupportedKind, error) {
-	var result []types.SupportedKind
+// Supported fetches the facilitator's v2 /supported response.
+func (c *Client) Supported(ctx context.Context) (*types.SupportedResponse, error) {
+	var result types.SupportedResponse
 	if err := c.doRequest(ctx, http.MethodGet, "/supported", nil, "", &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return &result, nil
 }
 
+// Verify asks the facilitator to validate a signed payment without
+// broadcasting it on-chain.
 func (c *Client) Verify(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
 	body := types.PaymentVerifyRequest{
-		X402Version:         int(types.X402VersionV1),
-		PaymentHeader:       *payload,
+		PaymentPayload:      *payload,
 		PaymentRequirements: *req,
 	}
 
@@ -52,11 +53,10 @@ func (c *Client) Verify(ctx context.Context, payload *types.PaymentPayload, req 
 	return &resp, nil
 }
 
-// Settle sends a payment settlement request.
+// Settle asks the facilitator to broadcast a verified payment on-chain.
 func (c *Client) Settle(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
 	body := types.PaymentSettleRequest{
-		X402Version:         int(types.X402VersionV1),
-		PaymentHeader:       *payload,
+		PaymentPayload:      *payload,
 		PaymentRequirements: *req,
 	}
 

--- a/api/server.go
+++ b/api/server.go
@@ -65,7 +65,7 @@ func (s *server) Settle(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Received malformed settlement request")
 	}
 
-	settle, err := s.facilitator.Settle(ctx, &settleRequest.PaymentHeader, &settleRequest.PaymentRequirements)
+	settle, err := s.facilitator.Settle(ctx, &settleRequest.PaymentPayload, &settleRequest.PaymentRequirements)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -92,7 +92,7 @@ func (s *server) Verify(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Received malformed payment requirements")
 	}
 
-	verified, err := s.facilitator.Verify(ctx, &requirement.PaymentHeader, &requirement.PaymentRequirements)
+	verified, err := s.facilitator.Verify(ctx, &requirement.PaymentPayload, &requirement.PaymentRequirements)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
@@ -105,14 +105,14 @@ func (s *server) Verify(c echo.Context) error {
 // @Description  Get supported payment kinds
 // @Tags         payments
 // @Produce      json
-// @Success      200  {array}   types.SupportedKind
+// @Success      200  {object}  types.SupportedResponse
 // @Failure      404  {object}  echo.HTTPError
 // @Router       /supported [get]
 func (s *server) Supported(c echo.Context) error {
-	kinds := s.facilitator.Supported()
-	if len(kinds) == 0 {
+	resp := s.facilitator.Supported()
+	if resp == nil || len(resp.Kinds) == 0 {
 		return echo.NewHTTPError(http.StatusNotFound, "No supported payment kinds found")
 	}
 
-	return c.JSON(http.StatusOK, kinds)
+	return c.JSON(http.StatusOK, resp)
 }

--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -75,10 +75,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.SupportedKind"
-                            }
+                            "$ref": "#/definitions/types.SupportedResponse"
                         }
                     },
                     "404": {
@@ -147,23 +144,34 @@ const docTemplate = `{
         "types.PaymentPayload": {
             "type": "object",
             "properties": {
-                "network": {
-                    "description": "Network ID of the accepted paymentRequirements the client is using to pay",
-                    "type": "string"
+                "accepted": {
+                    "description": "Accepted echoes the PaymentRequirements the client is paying\nagainst. Facilitators read scheme/network from here.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentRequirements"
+                        }
+                    ]
+                },
+                "extensions": {
+                    "description": "Extensions carries protocol extension data. Optional.",
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "payload": {
-                    "description": "Payload is E-dependent and may contain authorization and signature data",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "description": "Payload is the scheme-specific payment material (e.g. an EIP-3009\nauthorization + signature). Its shape depends on Accepted.Scheme.",
+                    "type": "object",
+                    "additionalProperties": true
                 },
-                "scheme": {
-                    "description": "Scheme value of the accepted paymentRequirements the client is using to pay",
-                    "type": "string"
+                "resource": {
+                    "description": "Resource describes the resource being paid for. Optional.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ResourceInfo"
+                        }
+                    ]
                 },
                 "x402Version": {
-                    "description": "Version of the x402 payment protocol",
+                    "description": "X402Version is the protocol version (always 2 for v2 payloads).",
                     "type": "integer"
                 }
             }
@@ -171,54 +179,33 @@ const docTemplate = `{
         "types.PaymentRequirements": {
             "type": "object",
             "properties": {
-                "asset": {
-                    "description": "Address of the EIP-3009 compliant ERC20 contract",
+                "amount": {
+                    "description": "Amount required to pay for the resource in atomic units, as a\ndecimal string. This replaces the v1 field \"maxAmountRequired\".",
                     "type": "string"
                 },
-                "description": {
-                    "description": "Description of the resource",
+                "asset": {
+                    "description": "Asset is the token contract address (EVM) or mint (SVM) being paid.",
                     "type": "string"
                 },
                 "extra": {
-                    "description": "Extra information about the payment details specific to the scheme",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "maxAmountRequired": {
-                    "description": "Maximum amount required to pay for the resource in atomic units",
-                    "type": "string"
+                    "description": "Extra carries scheme-specific metadata (e.g. the EIP-712 domain\nname and version for EIP-3009).",
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "maxTimeoutSeconds": {
-                    "description": "Maximum time in seconds for the resource server to respond",
+                    "description": "MaxTimeoutSeconds is the maximum time the resource server will\nwait for the payment to be facilitated.",
                     "type": "integer"
                 },
-                "mimeType": {
-                    "description": "MIME type of the resource response",
-                    "type": "string"
-                },
                 "network": {
-                    "description": "Network of the blockchain to send payment on (e.g., \"base-sepolia\")",
+                    "description": "Network in CAIP-2 format (e.g. \"eip155:84532\").",
                     "type": "string"
-                },
-                "outputSchema": {
-                    "description": "Output schema of the resource response (optional)",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 },
                 "payTo": {
-                    "description": "Address to pay value to",
-                    "type": "string"
-                },
-                "resource": {
-                    "description": "URL of the resource to pay for",
+                    "description": "PayTo is the address that receives the payment.",
                     "type": "string"
                 },
                 "scheme": {
-                    "description": "Scheme of the payment protocol to use (e.g., \"exact\")",
+                    "description": "Scheme of the payment protocol to use (e.g. \"exact\").",
                     "type": "string"
                 }
             }
@@ -226,34 +213,39 @@ const docTemplate = `{
         "types.PaymentSettleRequest": {
             "type": "object",
             "properties": {
-                "paymentHeader": {
+                "paymentPayload": {
                     "$ref": "#/definitions/types.PaymentPayload"
                 },
                 "paymentRequirements": {
                     "$ref": "#/definitions/types.PaymentRequirements"
-                },
-                "x402Version": {
-                    "type": "integer"
                 }
             }
         },
         "types.PaymentSettleResponse": {
             "type": "object",
             "properties": {
-                "error": {
-                    "description": "Error message, if any",
+                "errorMessage": {
+                    "description": "ErrorMessage is a human-readable explanation when Success is false.",
                     "type": "string"
                 },
-                "networkId": {
-                    "description": "Network ID where the transaction was submitted",
+                "errorReason": {
+                    "description": "ErrorReason is a short machine-readable code when Success is false.",
+                    "type": "string"
+                },
+                "network": {
+                    "description": "Network is the CAIP-2 network the transaction was submitted to.\nThis replaces the v1 field \"networkId\".",
+                    "type": "string"
+                },
+                "payer": {
+                    "description": "Payer is the address that signed the payment, when recoverable.",
                     "type": "string"
                 },
                 "success": {
-                    "description": "Whether the payment was successful",
+                    "description": "Success reports whether settlement broadcast was accepted.",
                     "type": "boolean"
                 },
-                "txHash": {
-                    "description": "Transaction hash of the settled payment",
+                "transaction": {
+                    "description": "Transaction is the on-chain transaction hash of the settled payment.\nThis replaces the v1 field \"txHash\".",
                     "type": "string"
                 }
             }
@@ -261,29 +253,45 @@ const docTemplate = `{
         "types.PaymentVerifyRequest": {
             "type": "object",
             "properties": {
-                "paymentHeader": {
+                "paymentPayload": {
                     "$ref": "#/definitions/types.PaymentPayload"
                 },
                 "paymentRequirements": {
                     "$ref": "#/definitions/types.PaymentRequirements"
-                },
-                "x402Version": {
-                    "type": "integer"
                 }
             }
         },
         "types.PaymentVerifyResponse": {
             "type": "object",
             "properties": {
+                "invalidMessage": {
+                    "description": "InvalidMessage is a human-readable explanation when IsValid is\nfalse. Clients may surface this to end users.",
+                    "type": "string"
+                },
                 "invalidReason": {
-                    "description": "Error message or reason for invalidity, if applicable",
+                    "description": "InvalidReason is a short machine-readable code (e.g.\n\"insufficient_balance\") when IsValid is false.",
                     "type": "string"
                 },
                 "isValid": {
-                    "description": "Whether the payment payload is valid",
+                    "description": "IsValid reports whether the payment payload is valid.",
                     "type": "boolean"
                 },
                 "payer": {
+                    "description": "Payer is the address that signed the payment, when recoverable.",
+                    "type": "string"
+                }
+            }
+        },
+        "types.ResourceInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "mimeType": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -291,11 +299,51 @@ const docTemplate = `{
         "types.SupportedKind": {
             "type": "object",
             "properties": {
+                "extra": {
+                    "description": "Extra carries scheme-specific metadata (e.g. the SVM fee payer).",
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "network": {
+                    "description": "Network in CAIP-2 format.",
                     "type": "string"
                 },
                 "scheme": {
+                    "description": "Scheme of the payment protocol (e.g. \"exact\").",
                     "type": "string"
+                },
+                "x402Version": {
+                    "description": "X402Version is the protocol version supported for this pair.",
+                    "type": "integer"
+                }
+            }
+        },
+        "types.SupportedResponse": {
+            "type": "object",
+            "properties": {
+                "extensions": {
+                    "description": "Extensions lists the x402 protocol extensions this facilitator\nhonours. Empty when no extensions are supported.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "kinds": {
+                    "description": "Kinds lists every accepted (scheme, network) pair.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.SupportedKind"
+                    }
+                },
+                "signers": {
+                    "description": "Signers maps a CAIP-2 family pattern (e.g. \"eip155:*\") to the\naddresses this facilitator may use as the sender of settlement\ntransactions on that family. Clients use this to allowlist or\naudit the facilitator's on-chain footprint.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         }

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -67,10 +67,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/types.SupportedKind"
-                            }
+                            "$ref": "#/definitions/types.SupportedResponse"
                         }
                     },
                     "404": {
@@ -139,23 +136,34 @@
         "types.PaymentPayload": {
             "type": "object",
             "properties": {
-                "network": {
-                    "description": "Network ID of the accepted paymentRequirements the client is using to pay",
-                    "type": "string"
+                "accepted": {
+                    "description": "Accepted echoes the PaymentRequirements the client is paying\nagainst. Facilitators read scheme/network from here.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.PaymentRequirements"
+                        }
+                    ]
+                },
+                "extensions": {
+                    "description": "Extensions carries protocol extension data. Optional.",
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "payload": {
-                    "description": "Payload is E-dependent and may contain authorization and signature data",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
+                    "description": "Payload is the scheme-specific payment material (e.g. an EIP-3009\nauthorization + signature). Its shape depends on Accepted.Scheme.",
+                    "type": "object",
+                    "additionalProperties": true
                 },
-                "scheme": {
-                    "description": "Scheme value of the accepted paymentRequirements the client is using to pay",
-                    "type": "string"
+                "resource": {
+                    "description": "Resource describes the resource being paid for. Optional.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.ResourceInfo"
+                        }
+                    ]
                 },
                 "x402Version": {
-                    "description": "Version of the x402 payment protocol",
+                    "description": "X402Version is the protocol version (always 2 for v2 payloads).",
                     "type": "integer"
                 }
             }
@@ -163,54 +171,33 @@
         "types.PaymentRequirements": {
             "type": "object",
             "properties": {
-                "asset": {
-                    "description": "Address of the EIP-3009 compliant ERC20 contract",
+                "amount": {
+                    "description": "Amount required to pay for the resource in atomic units, as a\ndecimal string. This replaces the v1 field \"maxAmountRequired\".",
                     "type": "string"
                 },
-                "description": {
-                    "description": "Description of the resource",
+                "asset": {
+                    "description": "Asset is the token contract address (EVM) or mint (SVM) being paid.",
                     "type": "string"
                 },
                 "extra": {
-                    "description": "Extra information about the payment details specific to the scheme",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "maxAmountRequired": {
-                    "description": "Maximum amount required to pay for the resource in atomic units",
-                    "type": "string"
+                    "description": "Extra carries scheme-specific metadata (e.g. the EIP-712 domain\nname and version for EIP-3009).",
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "maxTimeoutSeconds": {
-                    "description": "Maximum time in seconds for the resource server to respond",
+                    "description": "MaxTimeoutSeconds is the maximum time the resource server will\nwait for the payment to be facilitated.",
                     "type": "integer"
                 },
-                "mimeType": {
-                    "description": "MIME type of the resource response",
-                    "type": "string"
-                },
                 "network": {
-                    "description": "Network of the blockchain to send payment on (e.g., \"base-sepolia\")",
+                    "description": "Network in CAIP-2 format (e.g. \"eip155:84532\").",
                     "type": "string"
-                },
-                "outputSchema": {
-                    "description": "Output schema of the resource response (optional)",
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
                 },
                 "payTo": {
-                    "description": "Address to pay value to",
-                    "type": "string"
-                },
-                "resource": {
-                    "description": "URL of the resource to pay for",
+                    "description": "PayTo is the address that receives the payment.",
                     "type": "string"
                 },
                 "scheme": {
-                    "description": "Scheme of the payment protocol to use (e.g., \"exact\")",
+                    "description": "Scheme of the payment protocol to use (e.g. \"exact\").",
                     "type": "string"
                 }
             }
@@ -218,34 +205,39 @@
         "types.PaymentSettleRequest": {
             "type": "object",
             "properties": {
-                "paymentHeader": {
+                "paymentPayload": {
                     "$ref": "#/definitions/types.PaymentPayload"
                 },
                 "paymentRequirements": {
                     "$ref": "#/definitions/types.PaymentRequirements"
-                },
-                "x402Version": {
-                    "type": "integer"
                 }
             }
         },
         "types.PaymentSettleResponse": {
             "type": "object",
             "properties": {
-                "error": {
-                    "description": "Error message, if any",
+                "errorMessage": {
+                    "description": "ErrorMessage is a human-readable explanation when Success is false.",
                     "type": "string"
                 },
-                "networkId": {
-                    "description": "Network ID where the transaction was submitted",
+                "errorReason": {
+                    "description": "ErrorReason is a short machine-readable code when Success is false.",
+                    "type": "string"
+                },
+                "network": {
+                    "description": "Network is the CAIP-2 network the transaction was submitted to.\nThis replaces the v1 field \"networkId\".",
+                    "type": "string"
+                },
+                "payer": {
+                    "description": "Payer is the address that signed the payment, when recoverable.",
                     "type": "string"
                 },
                 "success": {
-                    "description": "Whether the payment was successful",
+                    "description": "Success reports whether settlement broadcast was accepted.",
                     "type": "boolean"
                 },
-                "txHash": {
-                    "description": "Transaction hash of the settled payment",
+                "transaction": {
+                    "description": "Transaction is the on-chain transaction hash of the settled payment.\nThis replaces the v1 field \"txHash\".",
                     "type": "string"
                 }
             }
@@ -253,29 +245,45 @@
         "types.PaymentVerifyRequest": {
             "type": "object",
             "properties": {
-                "paymentHeader": {
+                "paymentPayload": {
                     "$ref": "#/definitions/types.PaymentPayload"
                 },
                 "paymentRequirements": {
                     "$ref": "#/definitions/types.PaymentRequirements"
-                },
-                "x402Version": {
-                    "type": "integer"
                 }
             }
         },
         "types.PaymentVerifyResponse": {
             "type": "object",
             "properties": {
+                "invalidMessage": {
+                    "description": "InvalidMessage is a human-readable explanation when IsValid is\nfalse. Clients may surface this to end users.",
+                    "type": "string"
+                },
                 "invalidReason": {
-                    "description": "Error message or reason for invalidity, if applicable",
+                    "description": "InvalidReason is a short machine-readable code (e.g.\n\"insufficient_balance\") when IsValid is false.",
                     "type": "string"
                 },
                 "isValid": {
-                    "description": "Whether the payment payload is valid",
+                    "description": "IsValid reports whether the payment payload is valid.",
                     "type": "boolean"
                 },
                 "payer": {
+                    "description": "Payer is the address that signed the payment, when recoverable.",
+                    "type": "string"
+                }
+            }
+        },
+        "types.ResourceInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "mimeType": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -283,11 +291,51 @@
         "types.SupportedKind": {
             "type": "object",
             "properties": {
+                "extra": {
+                    "description": "Extra carries scheme-specific metadata (e.g. the SVM fee payer).",
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "network": {
+                    "description": "Network in CAIP-2 format.",
                     "type": "string"
                 },
                 "scheme": {
+                    "description": "Scheme of the payment protocol (e.g. \"exact\").",
                     "type": "string"
+                },
+                "x402Version": {
+                    "description": "X402Version is the protocol version supported for this pair.",
+                    "type": "integer"
+                }
+            }
+        },
+        "types.SupportedResponse": {
+            "type": "object",
+            "properties": {
+                "extensions": {
+                    "description": "Extensions lists the x402 protocol extensions this facilitator\nhonours. Empty when no extensions are supported.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "kinds": {
+                    "description": "Kinds lists every accepted (scheme, network) pair.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.SupportedKind"
+                    }
+                },
+                "signers": {
+                    "description": "Signers maps a CAIP-2 family pattern (e.g. \"eip155:*\") to the\naddresses this facilitator may use as the sender of settlement\ntransactions on that family. Clients use this to allowlist or\naudit the facilitator's on-chain footprint.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         }

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -5,114 +5,172 @@ definitions:
     type: object
   types.PaymentPayload:
     properties:
-      network:
-        description: Network ID of the accepted paymentRequirements the client is
-          using to pay
-        type: string
+      accepted:
+        allOf:
+        - $ref: '#/definitions/types.PaymentRequirements'
+        description: |-
+          Accepted echoes the PaymentRequirements the client is paying
+          against. Facilitators read scheme/network from here.
+      extensions:
+        additionalProperties: true
+        description: Extensions carries protocol extension data. Optional.
+        type: object
       payload:
-        description: Payload is E-dependent and may contain authorization and signature
-          data
-        items:
-          type: integer
-        type: array
-      scheme:
-        description: Scheme value of the accepted paymentRequirements the client is
-          using to pay
-        type: string
+        additionalProperties: true
+        description: |-
+          Payload is the scheme-specific payment material (e.g. an EIP-3009
+          authorization + signature). Its shape depends on Accepted.Scheme.
+        type: object
+      resource:
+        allOf:
+        - $ref: '#/definitions/types.ResourceInfo'
+        description: Resource describes the resource being paid for. Optional.
       x402Version:
-        description: Version of the x402 payment protocol
+        description: X402Version is the protocol version (always 2 for v2 payloads).
         type: integer
     type: object
   types.PaymentRequirements:
     properties:
-      asset:
-        description: Address of the EIP-3009 compliant ERC20 contract
+      amount:
+        description: |-
+          Amount required to pay for the resource in atomic units, as a
+          decimal string. This replaces the v1 field "maxAmountRequired".
         type: string
-      description:
-        description: Description of the resource
+      asset:
+        description: Asset is the token contract address (EVM) or mint (SVM) being
+          paid.
         type: string
       extra:
-        description: Extra information about the payment details specific to the scheme
-        items:
-          type: integer
-        type: array
-      maxAmountRequired:
-        description: Maximum amount required to pay for the resource in atomic units
-        type: string
+        additionalProperties: true
+        description: |-
+          Extra carries scheme-specific metadata (e.g. the EIP-712 domain
+          name and version for EIP-3009).
+        type: object
       maxTimeoutSeconds:
-        description: Maximum time in seconds for the resource server to respond
+        description: |-
+          MaxTimeoutSeconds is the maximum time the resource server will
+          wait for the payment to be facilitated.
         type: integer
-      mimeType:
-        description: MIME type of the resource response
-        type: string
       network:
-        description: Network of the blockchain to send payment on (e.g., "base-sepolia")
+        description: Network in CAIP-2 format (e.g. "eip155:84532").
         type: string
-      outputSchema:
-        description: Output schema of the resource response (optional)
-        items:
-          type: integer
-        type: array
       payTo:
-        description: Address to pay value to
-        type: string
-      resource:
-        description: URL of the resource to pay for
+        description: PayTo is the address that receives the payment.
         type: string
       scheme:
-        description: Scheme of the payment protocol to use (e.g., "exact")
+        description: Scheme of the payment protocol to use (e.g. "exact").
         type: string
     type: object
   types.PaymentSettleRequest:
     properties:
-      paymentHeader:
+      paymentPayload:
         $ref: '#/definitions/types.PaymentPayload'
       paymentRequirements:
         $ref: '#/definitions/types.PaymentRequirements'
-      x402Version:
-        type: integer
     type: object
   types.PaymentSettleResponse:
     properties:
-      error:
-        description: Error message, if any
+      errorMessage:
+        description: ErrorMessage is a human-readable explanation when Success is
+          false.
         type: string
-      networkId:
-        description: Network ID where the transaction was submitted
+      errorReason:
+        description: ErrorReason is a short machine-readable code when Success is
+          false.
+        type: string
+      network:
+        description: |-
+          Network is the CAIP-2 network the transaction was submitted to.
+          This replaces the v1 field "networkId".
+        type: string
+      payer:
+        description: Payer is the address that signed the payment, when recoverable.
         type: string
       success:
-        description: Whether the payment was successful
+        description: Success reports whether settlement broadcast was accepted.
         type: boolean
-      txHash:
-        description: Transaction hash of the settled payment
+      transaction:
+        description: |-
+          Transaction is the on-chain transaction hash of the settled payment.
+          This replaces the v1 field "txHash".
         type: string
     type: object
   types.PaymentVerifyRequest:
     properties:
-      paymentHeader:
+      paymentPayload:
         $ref: '#/definitions/types.PaymentPayload'
       paymentRequirements:
         $ref: '#/definitions/types.PaymentRequirements'
-      x402Version:
-        type: integer
     type: object
   types.PaymentVerifyResponse:
     properties:
+      invalidMessage:
+        description: |-
+          InvalidMessage is a human-readable explanation when IsValid is
+          false. Clients may surface this to end users.
+        type: string
       invalidReason:
-        description: Error message or reason for invalidity, if applicable
+        description: |-
+          InvalidReason is a short machine-readable code (e.g.
+          "insufficient_balance") when IsValid is false.
         type: string
       isValid:
-        description: Whether the payment payload is valid
+        description: IsValid reports whether the payment payload is valid.
         type: boolean
       payer:
+        description: Payer is the address that signed the payment, when recoverable.
+        type: string
+    type: object
+  types.ResourceInfo:
+    properties:
+      description:
+        type: string
+      mimeType:
+        type: string
+      url:
         type: string
     type: object
   types.SupportedKind:
     properties:
+      extra:
+        additionalProperties: true
+        description: Extra carries scheme-specific metadata (e.g. the SVM fee payer).
+        type: object
       network:
+        description: Network in CAIP-2 format.
         type: string
       scheme:
+        description: Scheme of the payment protocol (e.g. "exact").
         type: string
+      x402Version:
+        description: X402Version is the protocol version supported for this pair.
+        type: integer
+    type: object
+  types.SupportedResponse:
+    properties:
+      extensions:
+        description: |-
+          Extensions lists the x402 protocol extensions this facilitator
+          honours. Empty when no extensions are supported.
+        items:
+          type: string
+        type: array
+      kinds:
+        description: Kinds lists every accepted (scheme, network) pair.
+        items:
+          $ref: '#/definitions/types.SupportedKind'
+        type: array
+      signers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        description: |-
+          Signers maps a CAIP-2 family pattern (e.g. "eip155:*") to the
+          addresses this facilitator may use as the sender of settlement
+          transactions on that family. Clients use this to allowlist or
+          audit the facilitator's on-chain footprint.
+        type: object
     type: object
 info:
   contact: {}
@@ -159,9 +217,7 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/types.SupportedKind'
-            type: array
+            $ref: '#/definitions/types.SupportedResponse'
         "404":
           description: Not Found
           schema:

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -33,8 +33,8 @@ func init() {
 	fs := cmd.PersistentFlags()
 
 	fs.StringVarP(&url, "url", "u", "http://localhost:9090", "Base URL of the facilitator server")
-	fs.StringVarP(&scheme, "scheme", "s", "evm", "Scheme to use")
-	fs.StringVarP(&network, "network", "n", "base-sepolia", "Blockchain network to use")
+	fs.StringVarP(&scheme, "scheme", "s", "exact", "Payment scheme to use")
+	fs.StringVarP(&network, "network", "n", "eip155:84532", "CAIP-2 network to pay on (e.g. eip155:84532)")
 	fs.StringVarP(&token, "token", "t", "USDC", "token contract for sending")
 	fs.StringVarP(&from, "from", "F", "", "Sender address")
 	fs.StringVarP(&to, "to", "T", "", "Recipient address")
@@ -55,13 +55,14 @@ func run(cmd *cobra.Command, args []string) {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}
 
-	// Here you would implement the logic to interact with the facilitator server
-	// using the provided parameters.
+	// Build the signed payment payload for the selected scheme. Today the
+	// only supported scheme is "exact" on an eip155 network; the CLI
+	// routes on the scheme flag so new schemes can be added alongside it.
 	log.Info().Msg("Sending payment request")
 	var paymentPayload *types.PaymentPayload
 	var paymentRequirements *types.PaymentRequirements
 	switch scheme {
-	case "evm":
+	case "exact":
 		priv, err := hex.DecodeString(privkey)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Failed to decode private key")
@@ -90,17 +91,25 @@ func run(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		paymentPayload = &types.PaymentPayload{
-			X402Version: int(types.X402VersionV1),
-			Scheme:      scheme,
-			Network:     network,
-			Payload:     jsonPayload,
+		// v2 PaymentPayload carries its scheme-specific payload as a
+		// decoded map so clients built on the upstream x402 SDK can
+		// inspect it without parsing raw JSON.
+		var payloadMap map[string]interface{}
+		if err := json.Unmarshal(jsonPayload, &payloadMap); err != nil {
+			log.Fatal().Err(err).Msg("Failed to decode payload into map")
 		}
+
 		paymentRequirements = &types.PaymentRequirements{
 			Scheme:  scheme,
 			Network: network,
-			PayTo:   to,
 			Asset:   token,
+			Amount:  amount,
+			PayTo:   to,
+		}
+		paymentPayload = &types.PaymentPayload{
+			X402Version: int(types.X402VersionV2),
+			Payload:     payloadMap,
+			Accepted:    *paymentRequirements,
 		}
 	}
 

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -55,9 +55,7 @@ func run(cmd *cobra.Command, args []string) {
 		log.Fatal().Err(err).Msg("Failed to create client")
 	}
 
-	// Build the signed payment payload for the selected scheme. Today the
-	// only supported scheme is "exact" on an eip155 network; the CLI
-	// routes on the scheme flag so new schemes can be added alongside it.
+	// Build a signed payment for the selected scheme
 	log.Info().Msg("Sending payment request")
 	var paymentPayload *types.PaymentPayload
 	var paymentRequirements *types.PaymentRequirements
@@ -91,9 +89,7 @@ func run(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		// v2 PaymentPayload carries its scheme-specific payload as a
-		// decoded map so clients built on the upstream x402 SDK can
-		// inspect it without parsing raw JSON.
+		// v2 PaymentPayload.Payload is a decoded map, not raw JSON
 		var payloadMap map[string]interface{}
 		if err := json.Unmarshal(jsonPayload, &payloadMap); err != nil {
 			log.Fatal().Err(err).Msg("Failed to decode payload into map")

--- a/config.toml
+++ b/config.toml
@@ -2,8 +2,21 @@ port = 9090 # HTTP Port
 
 # Config for accessing blockchains
 # TODO: support multiple chains. For now, this facilitator only supports one chain at a time
-scheme = "evm"                   # "evm", "solana", "sui", "tron"
-network = "base-sepolia"         # Network name
-url = "https://sepolia.base.org" # URL of the blockchain
-privateKey = ""
 
+# Payment protocol scheme. Currently only "exact" is supported; the value
+# is the x402 v2 scheme identifier, not a chain name.
+scheme = "exact"
+
+# Network in CAIP-2 format. Examples:
+#   eip155:84532  — Base Sepolia
+#   eip155:8453   — Base mainnet
+#   eip155:42161  — Arbitrum One
+network = "eip155:84532"
+
+# RPC endpoint the facilitator uses to verify and broadcast transactions
+# on the configured network.
+url = "https://sepolia.base.org"
+
+# Private key of the facilitator's fee payer (hex, no 0x prefix). Leave
+# empty in the repo; inject via your deployment's secret management.
+privateKey = ""

--- a/facilitator/evm.go
+++ b/facilitator/evm.go
@@ -76,10 +76,7 @@ func NewEVMFacilitator(network string, url string, privateKeyHex string) (*EVMFa
 	}, nil
 }
 
-// Verify detects the payload type and routes to the appropriate verification
-// method. v2 PaymentPayload.Payload is a decoded map, so we re-marshal it
-// once here and hand the JSON bytes to the scheme/evm helpers (which still
-// operate on bytes). This keeps scheme/evm untouched in the v2 migration.
+// Verify detects the payload type and routes to the appropriate verification method.
 func (t *EVMFacilitator) Verify(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
 	raw, err := json.Marshal(payload.Payload)
 	if err != nil {
@@ -109,10 +106,6 @@ func (t *EVMFacilitator) Settle(ctx context.Context, payload *types.PaymentPaylo
 	return t.settleEIP3009(ctx, payload, req, raw)
 }
 
-// Supported advertises this facilitator on /supported. It reports the
-// single (scheme, network) pair this instance was configured for, and
-// exposes its fee-payer address under the "eip155:*" CAIP-2 family so
-// clients can allowlist or audit the facilitator's on-chain sender.
 func (t *EVMFacilitator) Supported() *types.SupportedResponse {
 	return &types.SupportedResponse{
 		Kinds: []types.SupportedKind{{

--- a/facilitator/evm.go
+++ b/facilitator/evm.go
@@ -66,7 +66,7 @@ func NewEVMFacilitator(network string, url string, privateKeyHex string) (*EVMFa
 	}
 
 	return &EVMFacilitator{
-		scheme:    types.EVM,
+		scheme:    types.Exact,
 		network:   network,
 		networkID: networkId,
 
@@ -76,27 +76,53 @@ func NewEVMFacilitator(network string, url string, privateKeyHex string) (*EVMFa
 	}, nil
 }
 
-// Verify detects the payload type and routes to the appropriate verification method.
+// Verify detects the payload type and routes to the appropriate verification
+// method. v2 PaymentPayload.Payload is a decoded map, so we re-marshal it
+// once here and hand the JSON bytes to the scheme/evm helpers (which still
+// operate on bytes). This keeps scheme/evm untouched in the v2 migration.
 func (t *EVMFacilitator) Verify(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
-	if evm.IsPermit2PayloadJSON(payload.Payload) {
-		return t.verifyPermit2(ctx, payload, req)
+	raw, err := json.Marshal(payload.Payload)
+	if err != nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
+		}, nil
 	}
-	return t.verifyEIP3009(ctx, payload, req)
+	if evm.IsPermit2PayloadJSON(raw) {
+		return t.verifyPermit2(ctx, payload, req, raw)
+	}
+	return t.verifyEIP3009(ctx, payload, req, raw)
 }
 
 // Settle detects the payload type and routes to the appropriate settlement method.
 func (t *EVMFacilitator) Settle(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
-	if evm.IsPermit2PayloadJSON(payload.Payload) {
-		return t.settlePermit2(ctx, payload, req)
+	raw, err := json.Marshal(payload.Payload)
+	if err != nil {
+		return &types.PaymentSettleResponse{
+			Success:     false,
+			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
+		}, nil
 	}
-	return t.settleEIP3009(ctx, payload, req)
+	if evm.IsPermit2PayloadJSON(raw) {
+		return t.settlePermit2(ctx, payload, req, raw)
+	}
+	return t.settleEIP3009(ctx, payload, req, raw)
 }
 
-func (t *EVMFacilitator) Supported() []*types.SupportedKind {
-	return []*types.SupportedKind{
-		{
-			Scheme:  string(t.scheme),
-			Network: t.network,
+// Supported advertises this facilitator on /supported. It reports the
+// single (scheme, network) pair this instance was configured for, and
+// exposes its fee-payer address under the "eip155:*" CAIP-2 family so
+// clients can allowlist or audit the facilitator's on-chain sender.
+func (t *EVMFacilitator) Supported() *types.SupportedResponse {
+	return &types.SupportedResponse{
+		Kinds: []types.SupportedKind{{
+			X402Version: int(types.X402VersionV2),
+			Scheme:      string(t.scheme),
+			Network:     t.network,
+		}},
+		Extensions: []string{},
+		Signers: map[string][]string{
+			"eip155:*": {t.address.Hex()},
 		},
 	}
 }
@@ -112,18 +138,18 @@ func (t *EVMFacilitator) Supported() []*types.SupportedKind {
 //   - ✅ verify value in payload is enough to cover paymentRequirements.maxAmountRequired
 //   - check min amount is above some threshold we think is reasonable for covering gas
 //   - verify resource is not already paid for (next version)
-func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
+func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements, raw []byte) (*types.PaymentVerifyResponse, error) {
 	// Step 1: Payload format
 	var evmPayload evm.EVMPayload
-	if err := json.Unmarshal([]byte(payload.Payload), &evmPayload); err != nil {
+	if err := json.Unmarshal(raw, &evmPayload); err != nil {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
 		}, nil
 	}
 
-	// Step 2: Scheme verification
-	if payload.Scheme != string(t.scheme) || req.Scheme != string(t.scheme) {
+	// Step 2: Scheme verification (scheme lives inside payload.Accepted in v2).
+	if payload.Accepted.Scheme != string(t.scheme) || req.Scheme != string(t.scheme) {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrIncompatibleScheme.Error(),
@@ -132,14 +158,14 @@ func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.Payme
 	}
 
 	// Step 3: Network info and Contract info
-	if payload.Network != t.network {
+	if payload.Accepted.Network != t.network {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrNetworkMismatch.Error(),
 			Payer:         evmPayload.Authorization.From.String(),
 		}, nil
 	}
-	chainID := evm.GetChainID(payload.Network)
+	chainID := evm.GetChainID(payload.Accepted.Network)
 	if chainID == nil {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
@@ -154,7 +180,7 @@ func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.Payme
 			Payer:         evmPayload.Authorization.From.String(),
 		}, nil
 	}
-	domainConfig := evm.GetDomainConfig(payload.Network, req.Asset)
+	domainConfig := evm.GetDomainConfig(payload.Accepted.Network, req.Asset)
 	if domainConfig == nil {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
@@ -224,28 +250,28 @@ func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.Payme
 	}, nil
 }
 
-func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
+func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements, raw []byte) (*types.PaymentSettleResponse, error) {
 	var evmPayload evm.EVMPayload
-	if err := json.Unmarshal([]byte(payload.Payload), &evmPayload); err != nil {
+	if err := json.Unmarshal(raw, &evmPayload); err != nil {
 		return &types.PaymentSettleResponse{
-			Success: false,
-			Error:   types.ErrInvalidPayloadFormat.Error(),
+			Success:     false,
+			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
 		}, nil
 	}
 
 	networkID := evm.GetChainID(req.Network)
 	if networkID == nil {
 		return &types.PaymentSettleResponse{
-			Success: false,
-			Error:   types.ErrInvalidNetwork.Error(),
+			Success:     false,
+			ErrorReason: types.ErrInvalidNetwork.Error(),
 		}, nil
 	}
 
-	domainConfig := evm.GetDomainConfig(payload.Network, req.Asset)
+	domainConfig := evm.GetDomainConfig(req.Network, req.Asset)
 	if domainConfig == nil {
 		return &types.PaymentSettleResponse{
-			Success: false,
-			Error:   types.ErrTokenMismatch.Error(),
+			Success:     false,
+			ErrorReason: types.ErrTokenMismatch.Error(),
 		}, nil
 	}
 	contract, err := eip3009.NewEip3009(domainConfig.VerifyingContract, t.client)
@@ -276,9 +302,10 @@ func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.Payme
 	}
 
 	return &types.PaymentSettleResponse{
-		Success:   true,
-		TxHash:    tx.Hash().Hex(),
-		NetworkId: fmt.Sprintf("%d", networkID),
+		Success:     true,
+		Payer:       evmPayload.Authorization.From.String(),
+		Transaction: tx.Hash().Hex(),
+		Network:     types.Network(req.Network),
 	}, nil
 }
 
@@ -295,10 +322,10 @@ func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.Payme
 //   - ✅ verify token matches requirement asset
 //   - ✅ verify EIP-712 signature
 //   - ✅ verify client has enough balance
-func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error) {
+func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements, raw []byte) (*types.PaymentVerifyResponse, error) {
 	// Step 1: Parse Permit2 payload
 	var permit2Payload evm.Permit2Payload
-	if err := json.Unmarshal([]byte(payload.Payload), &permit2Payload); err != nil {
+	if err := json.Unmarshal(raw, &permit2Payload); err != nil {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
@@ -313,8 +340,8 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 		}, nil
 	}
 
-	// Step 2: Scheme verification
-	if payload.Scheme != string(t.scheme) || req.Scheme != string(t.scheme) {
+	// Step 2: Scheme verification (scheme lives inside payload.Accepted in v2).
+	if payload.Accepted.Scheme != string(t.scheme) || req.Scheme != string(t.scheme) {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrIncompatibleScheme.Error(),
@@ -323,14 +350,14 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 	}
 
 	// Step 3: Network verification
-	if payload.Network != t.network {
+	if payload.Accepted.Network != t.network {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
 			InvalidReason: types.ErrNetworkMismatch.Error(),
 			Payer:         auth.From.String(),
 		}, nil
 	}
-	chainID := evm.GetChainID(payload.Network)
+	chainID := evm.GetChainID(payload.Accepted.Network)
 	if chainID == nil {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
@@ -385,7 +412,7 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 	}
 
 	// Step 8: Amount must exactly match requirement
-	reqAmount, ok := new(big.Int).SetString(req.MaxAmountRequired, 10)
+	reqAmount, ok := new(big.Int).SetString(req.Amount, 10)
 	if !ok {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
@@ -402,7 +429,7 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 	}
 
 	// Step 9: Token matches requirement asset
-	tokenAddr := evm.GetTokenAddress(payload.Network, req.Asset)
+	tokenAddr := evm.GetTokenAddress(payload.Accepted.Network, req.Asset)
 	if tokenAddr == (common.Address{}) {
 		return &types.PaymentVerifyResponse{
 			IsValid:       false,
@@ -468,28 +495,28 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 	}, nil
 }
 
-func (t *EVMFacilitator) settlePermit2(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error) {
+func (t *EVMFacilitator) settlePermit2(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements, raw []byte) (*types.PaymentSettleResponse, error) {
 	var permit2Payload evm.Permit2Payload
-	if err := json.Unmarshal([]byte(payload.Payload), &permit2Payload); err != nil {
+	if err := json.Unmarshal(raw, &permit2Payload); err != nil {
 		return &types.PaymentSettleResponse{
-			Success: false,
-			Error:   types.ErrInvalidPayloadFormat.Error(),
+			Success:     false,
+			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
 		}, nil
 	}
 	auth := permit2Payload.Permit2Authorization
 	if auth == nil || auth.Nonce == nil || auth.Deadline == nil ||
 		auth.Permitted.Amount == nil || auth.Witness.ValidAfter == nil {
 		return &types.PaymentSettleResponse{
-			Success: false,
-			Error:   types.ErrInvalidPayloadFormat.Error(),
+			Success:     false,
+			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
 		}, nil
 	}
 
 	networkID := evm.GetChainID(req.Network)
 	if networkID == nil {
 		return &types.PaymentSettleResponse{
-			Success: false,
-			Error:   types.ErrInvalidNetwork.Error(),
+			Success:     false,
+			ErrorReason: types.ErrInvalidNetwork.Error(),
 		}, nil
 	}
 
@@ -538,8 +565,9 @@ func (t *EVMFacilitator) settlePermit2(ctx context.Context, payload *types.Payme
 	}
 
 	return &types.PaymentSettleResponse{
-		Success:   true,
-		TxHash:    tx.Hash().Hex(),
-		NetworkId: fmt.Sprintf("%d", networkID),
+		Success:     true,
+		Payer:       auth.From.String(),
+		Transaction: tx.Hash().Hex(),
+		Network:     types.Network(req.Network),
 	}, nil
 }

--- a/facilitator/evm.go
+++ b/facilitator/evm.go
@@ -140,6 +140,12 @@ func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.Payme
 			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
 		}, nil
 	}
+	if evmPayload.Authorization == nil {
+		return &types.PaymentVerifyResponse{
+			IsValid:       false,
+			InvalidReason: types.ErrInvalidPayloadFormat.Error(),
+		}, nil
+	}
 
 	// Step 2: Scheme verification (scheme lives inside payload.Accepted in v2).
 	if payload.Accepted.Scheme != string(t.scheme) || req.Scheme != string(t.scheme) {
@@ -244,19 +250,32 @@ func (t *EVMFacilitator) verifyEIP3009(ctx context.Context, payload *types.Payme
 }
 
 func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements, raw []byte) (*types.PaymentSettleResponse, error) {
+	network := types.Network(req.Network)
+
 	var evmPayload evm.EVMPayload
 	if err := json.Unmarshal(raw, &evmPayload); err != nil {
 		return &types.PaymentSettleResponse{
 			Success:     false,
 			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
+			Network:     network,
 		}, nil
 	}
+	if evmPayload.Authorization == nil {
+		return &types.PaymentSettleResponse{
+			Success:     false,
+			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
+			Network:     network,
+		}, nil
+	}
+	payer := evmPayload.Authorization.From.String()
 
 	networkID := evm.GetChainID(req.Network)
 	if networkID == nil {
 		return &types.PaymentSettleResponse{
 			Success:     false,
 			ErrorReason: types.ErrInvalidNetwork.Error(),
+			Payer:       payer,
+			Network:     network,
 		}, nil
 	}
 
@@ -265,15 +284,29 @@ func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.Payme
 		return &types.PaymentSettleResponse{
 			Success:     false,
 			ErrorReason: types.ErrTokenMismatch.Error(),
+			Payer:       payer,
+			Network:     network,
 		}, nil
 	}
 	contract, err := eip3009.NewEip3009(domainConfig.VerifyingContract, t.client)
 	if err != nil {
-		return nil, fmt.Errorf("contract bind failed: %w", err)
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  types.ErrContractBindFailed.Error(),
+			ErrorMessage: err.Error(),
+			Payer:        payer,
+			Network:      network,
+		}, nil
 	}
 	clientSig, err := evm.ParseSignature(evmPayload.Signature) // client signature
 	if err != nil {
-		return nil, err
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  types.ErrInvalidSignatureFormat.Error(),
+			ErrorMessage: err.Error(),
+			Payer:        payer,
+			Network:      network,
+		}, nil
 	}
 
 	tx, err := contract.TransferWithAuthorization(
@@ -291,14 +324,20 @@ func (t *EVMFacilitator) settleEIP3009(ctx context.Context, payload *types.Payme
 		clientSig,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to transfer with authorization %w", err)
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  types.ErrTransactionFailed.Error(),
+			ErrorMessage: err.Error(),
+			Payer:        payer,
+			Network:      network,
+		}, nil
 	}
 
 	return &types.PaymentSettleResponse{
 		Success:     true,
-		Payer:       evmPayload.Authorization.From.String(),
+		Payer:       payer,
 		Transaction: tx.Hash().Hex(),
-		Network:     types.Network(req.Network),
+		Network:     network,
 	}, nil
 }
 
@@ -489,11 +528,14 @@ func (t *EVMFacilitator) verifyPermit2(ctx context.Context, payload *types.Payme
 }
 
 func (t *EVMFacilitator) settlePermit2(ctx context.Context, payload *types.PaymentPayload, req *types.PaymentRequirements, raw []byte) (*types.PaymentSettleResponse, error) {
+	network := types.Network(req.Network)
+
 	var permit2Payload evm.Permit2Payload
 	if err := json.Unmarshal(raw, &permit2Payload); err != nil {
 		return &types.PaymentSettleResponse{
 			Success:     false,
 			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
+			Network:     network,
 		}, nil
 	}
 	auth := permit2Payload.Permit2Authorization
@@ -502,26 +544,42 @@ func (t *EVMFacilitator) settlePermit2(ctx context.Context, payload *types.Payme
 		return &types.PaymentSettleResponse{
 			Success:     false,
 			ErrorReason: types.ErrInvalidPayloadFormat.Error(),
+			Network:     network,
 		}, nil
 	}
+	payer := auth.From.String()
 
 	networkID := evm.GetChainID(req.Network)
 	if networkID == nil {
 		return &types.PaymentSettleResponse{
 			Success:     false,
 			ErrorReason: types.ErrInvalidNetwork.Error(),
+			Payer:       payer,
+			Network:     network,
 		}, nil
 	}
 
 	// Bind to x402ExactPermit2Proxy contract
 	proxyContract, err := permit2.NewPermit2(evm.X402ExactPermit2ProxyAddress, t.client)
 	if err != nil {
-		return nil, fmt.Errorf("permit2 proxy contract bind failed: %w", err)
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  types.ErrContractBindFailed.Error(),
+			ErrorMessage: err.Error(),
+			Payer:        payer,
+			Network:      network,
+		}, nil
 	}
 
 	clientSig, err := evm.ParseSignature(permit2Payload.Signature)
 	if err != nil {
-		return nil, err
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  types.ErrInvalidSignatureFormat.Error(),
+			ErrorMessage: err.Error(),
+			Payer:        payer,
+			Network:      network,
+		}, nil
 	}
 
 	// Build settle() arguments
@@ -554,13 +612,19 @@ func (t *EVMFacilitator) settlePermit2(ctx context.Context, payload *types.Payme
 		clientSig,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to settle permit2 payment: %w", err)
+		return &types.PaymentSettleResponse{
+			Success:      false,
+			ErrorReason:  types.ErrTransactionFailed.Error(),
+			ErrorMessage: err.Error(),
+			Payer:        payer,
+			Network:      network,
+		}, nil
 	}
 
 	return &types.PaymentSettleResponse{
 		Success:     true,
-		Payer:       auth.From.String(),
+		Payer:       payer,
 		Transaction: tx.Hash().Hex(),
-		Network:     types.Network(req.Network),
+		Network:     network,
 	}, nil
 }

--- a/facilitator/evm_test.go
+++ b/facilitator/evm_test.go
@@ -13,8 +13,9 @@ import (
 
 const (
 	PrivateKey = ""
-	Network    = "base-sepolia"
+	Network    = "eip155:84532"
 	Token      = "USDC"
+	Amount     = "10000"
 )
 
 func TestEVMVerify(t *testing.T) {
@@ -24,22 +25,24 @@ func TestEVMVerify(t *testing.T) {
 	privKey, err := hex.DecodeString("")
 	require.NoError(t, err)
 	evmPayload, err := evm.NewEVMPayload(Network, Token,
-		"", "", "10000", evm.NewRawPrivateSigner(privKey))
+		"", "", Amount, evm.NewRawPrivateSigner(privKey))
 	require.NoError(t, err)
 
 	evmPayloadJson, err := json.Marshal(evmPayload)
 	require.NoError(t, err)
+	var payloadMap map[string]interface{}
+	require.NoError(t, json.Unmarshal(evmPayloadJson, &payloadMap))
 
-	payload := &types.PaymentPayload{
-		X402Version: int(types.X402VersionV1),
-		Scheme:      string(types.EVM),
-		Network:     Network,
-		Payload:     evmPayloadJson,
-	}
 	req := &types.PaymentRequirements{
-		Scheme:  string(types.EVM),
+		Scheme:  string(types.Exact),
 		Network: Network,
 		Asset:   Token,
+		Amount:  Amount,
+	}
+	payload := &types.PaymentPayload{
+		X402Version: int(types.X402VersionV2),
+		Payload:     payloadMap,
+		Accepted:    *req,
 	}
 
 	res, err := facilitator.Verify(t.Context(), payload, req)
@@ -56,22 +59,23 @@ func TestEVMSettle(t *testing.T) {
 	privKey, err := hex.DecodeString("")
 	require.NoError(t, err)
 	evmPayload, err := evm.NewEVMPayload(Network, Token,
-		"", "", "10000", evm.NewRawPrivateSigner(privKey))
+		"", "", Amount, evm.NewRawPrivateSigner(privKey))
 	require.NoError(t, err)
 	evmPayloadJson, err := json.Marshal(evmPayload)
 	require.NoError(t, err)
-
-	payload := &types.PaymentPayload{
-		X402Version: int(types.X402VersionV1),
-		Scheme:      string(types.EVM),
-		Network:     Network,
-		Payload:     evmPayloadJson,
-	}
+	var payloadMap map[string]interface{}
+	require.NoError(t, json.Unmarshal(evmPayloadJson, &payloadMap))
 
 	req := &types.PaymentRequirements{
-		Scheme:  string(types.EVM),
+		Scheme:  string(types.Exact),
 		Network: Network,
 		Asset:   Token,
+		Amount:  Amount,
+	}
+	payload := &types.PaymentPayload{
+		X402Version: int(types.X402VersionV2),
+		Payload:     payloadMap,
+		Accepted:    *req,
 	}
 
 	res, err := facilitator.Settle(t.Context(), payload, req)

--- a/facilitator/iface.go
+++ b/facilitator/iface.go
@@ -3,27 +3,49 @@ package facilitator
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gosuda/x402-facilitator/types"
 )
 
+// Facilitator is the per-network payment facilitator interface. Each
+// implementation serves a single CAIP-2 network family (EVM, Solana, ...)
+// and exposes exactly one method per public HTTP endpoint: Verify,
+// Settle, and Supported.
 type Facilitator interface {
+	// Verify checks whether the payment payload is valid for the given
+	// requirements without broadcasting anything on-chain.
 	Verify(ctx context.Context, payment *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error)
+	// Settle broadcasts the payment on-chain and returns the transaction
+	// hash once the node accepts it.
 	Settle(ctx context.Context, payment *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error)
-	Supported() []*types.SupportedKind
+	// Supported returns the full /supported response for this facilitator
+	// — its advertised kinds, protocol extensions, and fee-payer signer
+	// addresses grouped by CAIP-2 family.
+	Supported() *types.SupportedResponse
 }
 
+// NewFacilitator constructs the facilitator for a given scheme and CAIP-2
+// network. This facilitator only implements the x402 v2 "exact" scheme;
+// the network family is inferred from the CAIP-2 namespace prefix.
 func NewFacilitator(scheme types.Scheme, network, rpcUrl string, privateKeyHex string) (Facilitator, error) {
-	switch scheme {
-	case types.EVM:
+	if scheme != types.Exact {
+		return nil, fmt.Errorf("unsupported scheme %q (only %q is implemented)", scheme, types.Exact)
+	}
+
+	// Route by CAIP-2 namespace prefix. The network value itself (e.g.
+	// "eip155:84532") is passed through to the per-family constructor so
+	// it can validate the concrete chain.
+	switch {
+	case strings.HasPrefix(network, "eip155:"):
 		return NewEVMFacilitator(network, rpcUrl, privateKeyHex)
-	case types.Solana:
+	case strings.HasPrefix(network, "solana:"):
 		return NewSolanaFacilitator(network, rpcUrl, privateKeyHex)
-	case types.Sui:
+	case strings.HasPrefix(network, "sui:"):
 		return NewSuiFacilitator(network, rpcUrl, privateKeyHex)
-	case types.Tron:
+	case strings.HasPrefix(network, "tron:"):
 		return NewTronFacilitator(network, rpcUrl, privateKeyHex)
 	default:
-		return nil, fmt.Errorf("unsupporsed scheme: %s", scheme)
+		return nil, fmt.Errorf("unsupported network %q: expected a CAIP-2 identifier (eip155:*, solana:*, sui:*, tron:*)", network)
 	}
 }

--- a/facilitator/iface.go
+++ b/facilitator/iface.go
@@ -8,34 +8,18 @@ import (
 	"github.com/gosuda/x402-facilitator/types"
 )
 
-// Facilitator is the per-network payment facilitator interface. Each
-// implementation serves a single CAIP-2 network family (EVM, Solana, ...)
-// and exposes exactly one method per public HTTP endpoint: Verify,
-// Settle, and Supported.
 type Facilitator interface {
-	// Verify checks whether the payment payload is valid for the given
-	// requirements without broadcasting anything on-chain.
 	Verify(ctx context.Context, payment *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentVerifyResponse, error)
-	// Settle broadcasts the payment on-chain and returns the transaction
-	// hash once the node accepts it.
 	Settle(ctx context.Context, payment *types.PaymentPayload, req *types.PaymentRequirements) (*types.PaymentSettleResponse, error)
-	// Supported returns the full /supported response for this facilitator
-	// — its advertised kinds, protocol extensions, and fee-payer signer
-	// addresses grouped by CAIP-2 family.
 	Supported() *types.SupportedResponse
 }
 
-// NewFacilitator constructs the facilitator for a given scheme and CAIP-2
-// network. This facilitator only implements the x402 v2 "exact" scheme;
-// the network family is inferred from the CAIP-2 namespace prefix.
 func NewFacilitator(scheme types.Scheme, network, rpcUrl string, privateKeyHex string) (Facilitator, error) {
 	if scheme != types.Exact {
 		return nil, fmt.Errorf("unsupported scheme %q (only %q is implemented)", scheme, types.Exact)
 	}
 
-	// Route by CAIP-2 namespace prefix. The network value itself (e.g.
-	// "eip155:84532") is passed through to the per-family constructor so
-	// it can validate the concrete chain.
+	// Route by CAIP-2 network prefix
 	switch {
 	case strings.HasPrefix(network, "eip155:"):
 		return NewEVMFacilitator(network, rpcUrl, privateKeyHex)

--- a/facilitator/solana.go
+++ b/facilitator/solana.go
@@ -45,11 +45,8 @@ func (t *SolanaFacilitator) Settle(ctx context.Context, payload *types.PaymentPa
 	return nil, nil
 }
 
-// Supported returns nil so this facilitator does not advertise itself on
-// /supported. Verify and Settle are still stubs; a follow-up PR will fill
-// them in and return a real SupportedResponse with a concrete CAIP-2
-// network identifier (e.g. solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) and
-// the fee-payer address under "solana:*".
+// Supported returns nil: Verify and Settle are not yet v2-compliant, so
+// this facilitator is gated from discovery until a follow-up lands.
 func (t *SolanaFacilitator) Supported() *types.SupportedResponse {
 	return nil
 }

--- a/facilitator/solana.go
+++ b/facilitator/solana.go
@@ -31,7 +31,7 @@ func NewSolanaFacilitator(network string, url string, privateKeyHex string) (*So
 	}
 
 	return &SolanaFacilitator{
-		scheme:   types.Solana,
+		scheme:   types.Exact,
 		client:   client,
 		feePayer: feePayer,
 	}, nil
@@ -45,11 +45,20 @@ func (t *SolanaFacilitator) Settle(ctx context.Context, payload *types.PaymentPa
 	return nil, nil
 }
 
-func (t *SolanaFacilitator) Supported() []*types.SupportedKind {
-	return []*types.SupportedKind{
-		{
-			Scheme:  string(types.Solana),
-			Network: string(types.Solana),
+// Supported advertises this facilitator on /supported. Solana Verify and
+// Settle are still stubs; the SupportedResponse carried here is a
+// placeholder that a follow-up commit gates to nil until a real
+// implementation lands.
+func (t *SolanaFacilitator) Supported() *types.SupportedResponse {
+	return &types.SupportedResponse{
+		Kinds: []types.SupportedKind{{
+			X402Version: int(types.X402VersionV2),
+			Scheme:      string(t.scheme),
+			Network:     "solana:*",
+		}},
+		Extensions: []string{},
+		Signers: map[string][]string{
+			"solana:*": {t.feePayer.PublicKey.String()},
 		},
 	}
 }

--- a/facilitator/solana.go
+++ b/facilitator/solana.go
@@ -45,20 +45,11 @@ func (t *SolanaFacilitator) Settle(ctx context.Context, payload *types.PaymentPa
 	return nil, nil
 }
 
-// Supported advertises this facilitator on /supported. Solana Verify and
-// Settle are still stubs; the SupportedResponse carried here is a
-// placeholder that a follow-up commit gates to nil until a real
-// implementation lands.
+// Supported returns nil so this facilitator does not advertise itself on
+// /supported. Verify and Settle are still stubs; a follow-up PR will fill
+// them in and return a real SupportedResponse with a concrete CAIP-2
+// network identifier (e.g. solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp) and
+// the fee-payer address under "solana:*".
 func (t *SolanaFacilitator) Supported() *types.SupportedResponse {
-	return &types.SupportedResponse{
-		Kinds: []types.SupportedKind{{
-			X402Version: int(types.X402VersionV2),
-			Scheme:      string(t.scheme),
-			Network:     "solana:*",
-		}},
-		Extensions: []string{},
-		Signers: map[string][]string{
-			"solana:*": {t.feePayer.PublicKey.String()},
-		},
-	}
+	return nil
 }

--- a/facilitator/sui.go
+++ b/facilitator/sui.go
@@ -21,11 +21,18 @@ func (t *SuiFacilitator) Settle(ctx context.Context, payload *types.PaymentPaylo
 	return nil, nil
 }
 
-func (t *SuiFacilitator) Supported() []*types.SupportedKind {
-	return []*types.SupportedKind{
-		{
-			Scheme:  string(types.Sui),
-			Network: string(types.Sui),
-		},
+// Supported advertises this facilitator on /supported. Sui Verify and
+// Settle are still stubs; the SupportedResponse carried here is a
+// placeholder that a follow-up commit gates to nil until a real
+// implementation lands.
+func (t *SuiFacilitator) Supported() *types.SupportedResponse {
+	return &types.SupportedResponse{
+		Kinds: []types.SupportedKind{{
+			X402Version: int(types.X402VersionV2),
+			Scheme:      string(types.Exact),
+			Network:     "sui:*",
+		}},
+		Extensions: []string{},
+		Signers:    map[string][]string{"sui:*": nil},
 	}
 }

--- a/facilitator/sui.go
+++ b/facilitator/sui.go
@@ -21,9 +21,8 @@ func (t *SuiFacilitator) Settle(ctx context.Context, payload *types.PaymentPaylo
 	return nil, nil
 }
 
-// Supported returns nil so this facilitator does not advertise itself on
-// /supported. Verify and Settle are still stubs; a follow-up PR will fill
-// them in and return a real SupportedResponse.
+// Supported returns nil: Verify and Settle are not yet v2-compliant, so
+// this facilitator is gated from discovery until a follow-up lands.
 func (t *SuiFacilitator) Supported() *types.SupportedResponse {
 	return nil
 }

--- a/facilitator/sui.go
+++ b/facilitator/sui.go
@@ -21,18 +21,9 @@ func (t *SuiFacilitator) Settle(ctx context.Context, payload *types.PaymentPaylo
 	return nil, nil
 }
 
-// Supported advertises this facilitator on /supported. Sui Verify and
-// Settle are still stubs; the SupportedResponse carried here is a
-// placeholder that a follow-up commit gates to nil until a real
-// implementation lands.
+// Supported returns nil so this facilitator does not advertise itself on
+// /supported. Verify and Settle are still stubs; a follow-up PR will fill
+// them in and return a real SupportedResponse.
 func (t *SuiFacilitator) Supported() *types.SupportedResponse {
-	return &types.SupportedResponse{
-		Kinds: []types.SupportedKind{{
-			X402Version: int(types.X402VersionV2),
-			Scheme:      string(types.Exact),
-			Network:     "sui:*",
-		}},
-		Extensions: []string{},
-		Signers:    map[string][]string{"sui:*": nil},
-	}
+	return nil
 }

--- a/facilitator/tron.go
+++ b/facilitator/tron.go
@@ -21,11 +21,18 @@ func (t *TronFacilitator) Settle(ctx context.Context, payload *types.PaymentPayl
 	return nil, nil
 }
 
-func (t *TronFacilitator) Supported() []*types.SupportedKind {
-	return []*types.SupportedKind{
-		{
-			Scheme:  string(types.Tron),
-			Network: string(types.Tron),
-		},
+// Supported advertises this facilitator on /supported. Tron Verify and
+// Settle are still stubs; the SupportedResponse carried here is a
+// placeholder that a follow-up commit gates to nil until a real
+// implementation lands.
+func (t *TronFacilitator) Supported() *types.SupportedResponse {
+	return &types.SupportedResponse{
+		Kinds: []types.SupportedKind{{
+			X402Version: int(types.X402VersionV2),
+			Scheme:      string(types.Exact),
+			Network:     "tron:*",
+		}},
+		Extensions: []string{},
+		Signers:    map[string][]string{"tron:*": nil},
 	}
 }

--- a/facilitator/tron.go
+++ b/facilitator/tron.go
@@ -21,18 +21,9 @@ func (t *TronFacilitator) Settle(ctx context.Context, payload *types.PaymentPayl
 	return nil, nil
 }
 
-// Supported advertises this facilitator on /supported. Tron Verify and
-// Settle are still stubs; the SupportedResponse carried here is a
-// placeholder that a follow-up commit gates to nil until a real
-// implementation lands.
+// Supported returns nil so this facilitator does not advertise itself on
+// /supported. Verify and Settle are still stubs; a follow-up PR will fill
+// them in and return a real SupportedResponse.
 func (t *TronFacilitator) Supported() *types.SupportedResponse {
-	return &types.SupportedResponse{
-		Kinds: []types.SupportedKind{{
-			X402Version: int(types.X402VersionV2),
-			Scheme:      string(types.Exact),
-			Network:     "tron:*",
-		}},
-		Extensions: []string{},
-		Signers:    map[string][]string{"tron:*": nil},
-	}
+	return nil
 }

--- a/facilitator/tron.go
+++ b/facilitator/tron.go
@@ -21,9 +21,8 @@ func (t *TronFacilitator) Settle(ctx context.Context, payload *types.PaymentPayl
 	return nil, nil
 }
 
-// Supported returns nil so this facilitator does not advertise itself on
-// /supported. Verify and Settle are still stubs; a follow-up PR will fill
-// them in and return a real SupportedResponse.
+// Supported returns nil: Verify and Settle are not yet v2-compliant, so
+// this facilitator is gated from discovery until a follow-up lands.
 func (t *TronFacilitator) Supported() *types.SupportedResponse {
 	return nil
 }

--- a/internal/sdk/sdk.go
+++ b/internal/sdk/sdk.go
@@ -23,8 +23,16 @@ type (
 	// PaymentRequirements defines the payment requirements from the resource server
 	PaymentRequirements = types.PaymentRequirements
 
+	// ResourceInfo describes the resource being paid for (moved out of
+	// PaymentRequirements and onto PaymentPayload in v2)
+	ResourceInfo = types.ResourceInfo
+
 	// SupportedKind represents a supported scheme and network pair
 	SupportedKind = types.SupportedKind
+
+	// SupportedResponse is the full /supported response body (kinds,
+	// protocol extensions, and signer addresses grouped by CAIP family)
+	SupportedResponse = types.SupportedResponse
 
 	// Network represents a blockchain network identifier (CAIP-2 format)
 	Network = x402.Network

--- a/scheme/evm/chaincfg.go
+++ b/scheme/evm/chaincfg.go
@@ -34,15 +34,16 @@ func GetChainName(chainID *big.Int) string {
 	return chainName[int(chainID.Int64())]
 }
 
+// chainName maps an EVM chain ID to its CAIP-2 network identifier.
+// Entries here must have a corresponding chainInfo row below — otherwise
+// NewEVMFacilitator would accept the network at constructor time and then
+// fail later inside GetDomainConfig at verify/settle time.
 var chainName = map[int]string{
-	1:        "ethereum",
-	11155111: "sepolia",
-	8453:     "base",
-	84532:    "base-sepolia",
-	10:       "optimism",
-	11155420: "optimism-sepolia",
-	42161:    "arbitrum",
-	421614:   "arbitrum-sepolia",
+	1:      "eip155:1",
+	8453:   "eip155:8453",
+	84532:  "eip155:84532",
+	42161:  "eip155:42161",
+	421614: "eip155:421614",
 }
 
 type ChainInfo struct {
@@ -80,7 +81,7 @@ func GetDomainConfig(chain, token string) *DomainConfig {
 }
 
 var chainInfo = map[string]ChainInfo{
-	"ethereum": {
+	"eip155:1": {
 		ChainID: big.NewInt(1),
 		TokenContracts: map[string]DomainConfig{
 			"USDC": {
@@ -91,7 +92,7 @@ var chainInfo = map[string]ChainInfo{
 			},
 		},
 	},
-	"base": {
+	"eip155:8453": {
 		ChainID:    big.NewInt(8453),
 		DefaultUrl: "https://mainnet.base.org",
 		TokenContracts: map[string]DomainConfig{
@@ -103,7 +104,7 @@ var chainInfo = map[string]ChainInfo{
 			},
 		},
 	},
-	"base-sepolia": {
+	"eip155:84532": {
 		ChainID:    big.NewInt(84532),
 		DefaultUrl: "https://sepolia.base.org",
 		TokenContracts: map[string]DomainConfig{
@@ -115,7 +116,7 @@ var chainInfo = map[string]ChainInfo{
 			},
 		},
 	},
-	"arbitrum": {
+	"eip155:42161": {
 		ChainID:    big.NewInt(42161),
 		DefaultUrl: "https://arb1.arbitrum.io/rpc",
 		TokenContracts: map[string]DomainConfig{
@@ -127,7 +128,7 @@ var chainInfo = map[string]ChainInfo{
 			},
 		},
 	},
-	"arbitrum-sepolia": {
+	"eip155:421614": {
 		ChainID:    big.NewInt(421614),
 		DefaultUrl: "https://sepolia-rollup.arbitrum.io/rpc",
 		TokenContracts: map[string]DomainConfig{

--- a/scheme/evm/chaincfg.go
+++ b/scheme/evm/chaincfg.go
@@ -68,16 +68,26 @@ func GetChainID(chain string) *big.Int {
 	return chainInfo.ChainID
 }
 
-func GetDomainConfig(chain, token string) *DomainConfig {
-	chainInfo, ok := chainInfo[chain]
+func GetDomainConfig(chain, asset string) *DomainConfig {
+	info, ok := chainInfo[chain]
 	if !ok {
 		return nil
 	}
-	domainConfig, ok := chainInfo.TokenContracts[token]
+	// v2 callers send the token contract address; reverse-resolve by VerifyingContract.
+	if strings.HasPrefix(asset, "0x") && len(asset) == 42 {
+		addr := common.HexToAddress(asset)
+		for _, cfg := range info.TokenContracts {
+			if cfg.VerifyingContract == addr {
+				return &cfg
+			}
+		}
+		return nil
+	}
+	cfg, ok := info.TokenContracts[asset]
 	if !ok {
 		return nil
 	}
-	return &domainConfig
+	return &cfg
 }
 
 var chainInfo = map[string]ChainInfo{

--- a/scheme/evm/chaincfg_test.go
+++ b/scheme/evm/chaincfg_test.go
@@ -1,0 +1,60 @@
+package evm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDomainConfig(t *testing.T) {
+	const (
+		baseSepolia     = "eip155:84532"
+		usdcBaseSepolia = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+	)
+
+	t.Run("resolves by token symbol", func(t *testing.T) {
+		cfg := GetDomainConfig(baseSepolia, "USDC")
+		require.NotNil(t, cfg, "symbol lookup should succeed for known token")
+		require.Equal(t, common.HexToAddress(usdcBaseSepolia), cfg.VerifyingContract)
+		require.Equal(t, "USDC", cfg.Name)
+	})
+
+	t.Run("resolves by contract address", func(t *testing.T) {
+		cfg := GetDomainConfig(baseSepolia, usdcBaseSepolia)
+		require.NotNil(t, cfg, "address lookup should succeed for known token")
+		require.Equal(t, common.HexToAddress(usdcBaseSepolia), cfg.VerifyingContract)
+		require.Equal(t, "USDC", cfg.Name)
+	})
+
+	t.Run("address lookup is case-insensitive", func(t *testing.T) {
+		cfg := GetDomainConfig(baseSepolia, strings.ToLower(usdcBaseSepolia))
+		require.NotNil(t, cfg, "lowercase address should still resolve")
+		require.Equal(t, common.HexToAddress(usdcBaseSepolia), cfg.VerifyingContract)
+	})
+
+	t.Run("symbol lookup and address lookup return the same config", func(t *testing.T) {
+		bySymbol := GetDomainConfig(baseSepolia, "USDC")
+		byAddress := GetDomainConfig(baseSepolia, usdcBaseSepolia)
+		require.NotNil(t, bySymbol)
+		require.NotNil(t, byAddress)
+		require.Equal(t, bySymbol.VerifyingContract, byAddress.VerifyingContract)
+		require.Equal(t, bySymbol.Name, byAddress.Name)
+		require.Equal(t, bySymbol.Version, byAddress.Version)
+		require.Equal(t, bySymbol.ChainID.String(), byAddress.ChainID.String())
+	})
+
+	t.Run("returns nil for unknown chain", func(t *testing.T) {
+		require.Nil(t, GetDomainConfig("eip155:999999", "USDC"))
+		require.Nil(t, GetDomainConfig("eip155:999999", usdcBaseSepolia))
+	})
+
+	t.Run("returns nil for unknown symbol on known chain", func(t *testing.T) {
+		require.Nil(t, GetDomainConfig(baseSepolia, "WETH"))
+	})
+
+	t.Run("returns nil for unknown contract address on known chain", func(t *testing.T) {
+		require.Nil(t, GetDomainConfig(baseSepolia, "0x0000000000000000000000000000000000000000"))
+	})
+}

--- a/scheme/evm/signer_test.go
+++ b/scheme/evm/signer_test.go
@@ -43,7 +43,7 @@ func TestPayloadSignVerify(t *testing.T) {
 	signer := NewRawPrivateSigner(privKey.Serialize())
 
 	// Create a message to sign
-	chain := "base-sepolia"
+	chain := "eip155:84532"
 	token := "USDC"
 
 	payload, err := NewEVMPayload(chain, token,
@@ -103,7 +103,7 @@ func TestPermit2PayloadSignVerify(t *testing.T) {
 
 	signer := NewRawPrivateSigner(privKey.Serialize())
 
-	chain := "base-sepolia"
+	chain := "eip155:84532"
 	token := "USDC"
 
 	payload, err := NewPermit2Payload(chain, token,

--- a/scheme/evm/types.go
+++ b/scheme/evm/types.go
@@ -70,6 +70,49 @@ type Authorization struct {
 	Nonce       [32]byte
 }
 
+type authorizationWire struct {
+	From        string `json:"from"`
+	To          string `json:"to"`
+	Value       string `json:"value"`
+	ValidAfter  string `json:"validAfter"`
+	ValidBefore string `json:"validBefore"`
+	Nonce       string `json:"nonce"`
+}
+
+func (a Authorization) MarshalJSON() ([]byte, error) {
+	return json.Marshal(authorizationWire{
+		From:        a.From.Hex(),
+		To:          a.To.Hex(),
+		Value:       decimalBigInt(a.Value),
+		ValidAfter:  decimalBigInt(a.ValidAfter),
+		ValidBefore: decimalBigInt(a.ValidBefore),
+		Nonce:       hex32(a.Nonce),
+	})
+}
+
+func (a *Authorization) UnmarshalJSON(data []byte) error {
+	var w authorizationWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	a.From = common.HexToAddress(w.From)
+	a.To = common.HexToAddress(w.To)
+	var err error
+	if a.Value, err = parseDecimalBigInt(w.Value); err != nil {
+		return fmt.Errorf("authorization.value: %w", err)
+	}
+	if a.ValidAfter, err = parseDecimalBigInt(w.ValidAfter); err != nil {
+		return fmt.Errorf("authorization.validAfter: %w", err)
+	}
+	if a.ValidBefore, err = parseDecimalBigInt(w.ValidBefore); err != nil {
+		return fmt.Errorf("authorization.validBefore: %w", err)
+	}
+	if a.Nonce, err = parseHex32(w.Nonce); err != nil {
+		return fmt.Errorf("authorization.nonce: %w", err)
+	}
+	return nil
+}
+
 var (
 	// EIP-3009 domain separator
 	AuthorizationTypeHash = Keccak256([]byte("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"))
@@ -169,6 +212,43 @@ func leftPadBytes(b []byte, size int) []byte {
 	return padded
 }
 
+func decimalBigInt(n *big.Int) string {
+	if n == nil {
+		return "0"
+	}
+	return n.String()
+}
+
+func parseDecimalBigInt(s string) (*big.Int, error) {
+	if s == "" {
+		return nil, errors.New("empty decimal")
+	}
+	n, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid decimal %q", s)
+	}
+	return n, nil
+}
+
+func hex32(b [32]byte) string {
+	return "0x" + hex.EncodeToString(b[:])
+}
+
+func parseHex32(s string) ([32]byte, error) {
+	var out [32]byte
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return out, fmt.Errorf("invalid hex: %w", err)
+	}
+	if len(b) != 32 {
+		return out, fmt.Errorf("expected 32 bytes, got %d", len(b))
+	}
+	copy(out[:], b)
+	return out, nil
+}
+
 // Utility to convert hex string to Address
 func ParseAddress(hexStr string) (common.Address, error) {
 	var a common.Address
@@ -187,10 +267,60 @@ type Permit2TokenPermissions struct {
 	Amount *big.Int       `json:"amount"`
 }
 
+type permit2TokenPermissionsWire struct {
+	Token  string `json:"token"`
+	Amount string `json:"amount"`
+}
+
+func (p Permit2TokenPermissions) MarshalJSON() ([]byte, error) {
+	return json.Marshal(permit2TokenPermissionsWire{
+		Token:  p.Token.Hex(),
+		Amount: decimalBigInt(p.Amount),
+	})
+}
+
+func (p *Permit2TokenPermissions) UnmarshalJSON(data []byte) error {
+	var w permit2TokenPermissionsWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	p.Token = common.HexToAddress(w.Token)
+	var err error
+	if p.Amount, err = parseDecimalBigInt(w.Amount); err != nil {
+		return fmt.Errorf("permit2TokenPermissions.amount: %w", err)
+	}
+	return nil
+}
+
 // Permit2Witness represents witness data for x402ExactPermit2Proxy.
 type Permit2Witness struct {
 	To         common.Address `json:"to"`
 	ValidAfter *big.Int       `json:"validAfter"`
+}
+
+type permit2WitnessWire struct {
+	To         string `json:"to"`
+	ValidAfter string `json:"validAfter"`
+}
+
+func (pw Permit2Witness) MarshalJSON() ([]byte, error) {
+	return json.Marshal(permit2WitnessWire{
+		To:         pw.To.Hex(),
+		ValidAfter: decimalBigInt(pw.ValidAfter),
+	})
+}
+
+func (pw *Permit2Witness) UnmarshalJSON(data []byte) error {
+	var w permit2WitnessWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	pw.To = common.HexToAddress(w.To)
+	var err error
+	if pw.ValidAfter, err = parseDecimalBigInt(w.ValidAfter); err != nil {
+		return fmt.Errorf("permit2Witness.validAfter: %w", err)
+	}
+	return nil
 }
 
 // Permit2Authorization represents the PermitWitnessTransferFrom parameters.
@@ -201,6 +331,45 @@ type Permit2Authorization struct {
 	Nonce     *big.Int                `json:"nonce"`
 	Deadline  *big.Int                `json:"deadline"`
 	Witness   Permit2Witness          `json:"witness"`
+}
+
+type permit2AuthorizationWire struct {
+	From      string                  `json:"from"`
+	Permitted Permit2TokenPermissions `json:"permitted"`
+	Spender   string                  `json:"spender"`
+	Nonce     string                  `json:"nonce"`
+	Deadline  string                  `json:"deadline"`
+	Witness   Permit2Witness          `json:"witness"`
+}
+
+func (a Permit2Authorization) MarshalJSON() ([]byte, error) {
+	return json.Marshal(permit2AuthorizationWire{
+		From:      a.From.Hex(),
+		Permitted: a.Permitted,
+		Spender:   a.Spender.Hex(),
+		Nonce:     decimalBigInt(a.Nonce),
+		Deadline:  decimalBigInt(a.Deadline),
+		Witness:   a.Witness,
+	})
+}
+
+func (a *Permit2Authorization) UnmarshalJSON(data []byte) error {
+	var w permit2AuthorizationWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	a.From = common.HexToAddress(w.From)
+	a.Permitted = w.Permitted
+	a.Spender = common.HexToAddress(w.Spender)
+	var err error
+	if a.Nonce, err = parseDecimalBigInt(w.Nonce); err != nil {
+		return fmt.Errorf("permit2Authorization.nonce: %w", err)
+	}
+	if a.Deadline, err = parseDecimalBigInt(w.Deadline); err != nil {
+		return fmt.Errorf("permit2Authorization.deadline: %w", err)
+	}
+	a.Witness = w.Witness
+	return nil
 }
 
 // Permit2Payload represents a Permit2 payment payload.

--- a/scheme/evm/types_test.go
+++ b/scheme/evm/types_test.go
@@ -1,0 +1,230 @@
+package evm
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gosuda/x402-facilitator/internal/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizationWireCompat(t *testing.T) {
+	const nonceHex = "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+	var nonce [32]byte
+	nonceBytes, err := hex.DecodeString(nonceHex[2:])
+	require.NoError(t, err)
+	copy(nonce[:], nonceBytes)
+
+	local := Authorization{
+		From:        common.HexToAddress("0x47322Ca28a85B12a7EA64a251Cd8b9Ea1fac037b"),
+		To:          common.HexToAddress("0x1234567890123456789012345678901234567890"),
+		Value:       big.NewInt(10000),
+		ValidAfter:  big.NewInt(0),
+		ValidBefore: big.NewInt(9999999999),
+		Nonce:       nonce,
+	}
+
+	t.Run("marshal matches upstream wire shape", func(t *testing.T) {
+		data, err := json.Marshal(local)
+		require.NoError(t, err)
+
+		var upstream sdk.ExactEIP3009Authorization
+		require.NoError(t, json.Unmarshal(data, &upstream))
+
+		require.Equal(t, local.From, common.HexToAddress(upstream.From))
+		require.Equal(t, local.To, common.HexToAddress(upstream.To))
+		require.Equal(t, "10000", upstream.Value)
+		require.Equal(t, "0", upstream.ValidAfter)
+		require.Equal(t, "9999999999", upstream.ValidBefore)
+		require.Equal(t, nonceHex, upstream.Nonce)
+	})
+
+	t.Run("unmarshal from upstream wire shape", func(t *testing.T) {
+		upstream := sdk.ExactEIP3009Authorization{
+			From:        local.From.Hex(),
+			To:          local.To.Hex(),
+			Value:       "10000",
+			ValidAfter:  "0",
+			ValidBefore: "9999999999",
+			Nonce:       nonceHex,
+		}
+		data, err := json.Marshal(upstream)
+		require.NoError(t, err)
+
+		var decoded Authorization
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, local.From, decoded.From)
+		require.Equal(t, local.To, decoded.To)
+		require.Equal(t, 0, local.Value.Cmp(decoded.Value))
+		require.Equal(t, 0, local.ValidAfter.Cmp(decoded.ValidAfter))
+		require.Equal(t, 0, local.ValidBefore.Cmp(decoded.ValidBefore))
+		require.Equal(t, local.Nonce, decoded.Nonce)
+	})
+
+	t.Run("round-trip preserves fields", func(t *testing.T) {
+		data, err := json.Marshal(local)
+		require.NoError(t, err)
+		var decoded Authorization
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, local.From, decoded.From)
+		require.Equal(t, local.To, decoded.To)
+		require.Equal(t, 0, local.Value.Cmp(decoded.Value))
+		require.Equal(t, 0, local.ValidAfter.Cmp(decoded.ValidAfter))
+		require.Equal(t, 0, local.ValidBefore.Cmp(decoded.ValidBefore))
+		require.Equal(t, local.Nonce, decoded.Nonce)
+	})
+
+	t.Run("rejects invalid decimal", func(t *testing.T) {
+		var decoded Authorization
+		err := json.Unmarshal([]byte(`{"from":"0x0","to":"0x0","value":"not-a-number","validAfter":"0","validBefore":"0","nonce":"`+nonceHex+`"}`), &decoded)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects wrong nonce length", func(t *testing.T) {
+		var decoded Authorization
+		err := json.Unmarshal([]byte(`{"from":"0x0","to":"0x0","value":"0","validAfter":"0","validBefore":"0","nonce":"0xabcd"}`), &decoded)
+		require.Error(t, err)
+	})
+}
+
+func TestPermit2AuthorizationWireCompat(t *testing.T) {
+	local := Permit2Authorization{
+		From: common.HexToAddress("0x47322Ca28a85B12a7EA64a251Cd8b9Ea1fac037b"),
+		Permitted: Permit2TokenPermissions{
+			Token:  common.HexToAddress("0x036CbD53842c5426634e7929541eC2318f3dCF7e"),
+			Amount: big.NewInt(1000000),
+		},
+		Spender:  X402ExactPermit2ProxyAddress,
+		Nonce:    big.NewInt(42),
+		Deadline: big.NewInt(9999999999),
+		Witness: Permit2Witness{
+			To:         common.HexToAddress("0x1234567890123456789012345678901234567890"),
+			ValidAfter: big.NewInt(0),
+		},
+	}
+
+	t.Run("marshal matches upstream wire shape", func(t *testing.T) {
+		data, err := json.Marshal(local)
+		require.NoError(t, err)
+
+		var upstream sdk.Permit2Authorization
+		require.NoError(t, json.Unmarshal(data, &upstream))
+
+		require.Equal(t, local.From, common.HexToAddress(upstream.From))
+		require.Equal(t, local.Permitted.Token, common.HexToAddress(upstream.Permitted.Token))
+		require.Equal(t, "1000000", upstream.Permitted.Amount)
+		require.Equal(t, local.Spender, common.HexToAddress(upstream.Spender))
+		require.Equal(t, "42", upstream.Nonce)
+		require.Equal(t, "9999999999", upstream.Deadline)
+		require.Equal(t, local.Witness.To, common.HexToAddress(upstream.Witness.To))
+		require.Equal(t, "0", upstream.Witness.ValidAfter)
+	})
+
+	t.Run("unmarshal from upstream wire shape", func(t *testing.T) {
+		upstream := sdk.Permit2Authorization{
+			From: local.From.Hex(),
+			Permitted: sdk.Permit2TokenPermissions{
+				Token:  local.Permitted.Token.Hex(),
+				Amount: "1000000",
+			},
+			Spender:  local.Spender.Hex(),
+			Nonce:    "42",
+			Deadline: "9999999999",
+			Witness: sdk.Permit2Witness{
+				To:         local.Witness.To.Hex(),
+				ValidAfter: "0",
+			},
+		}
+		data, err := json.Marshal(upstream)
+		require.NoError(t, err)
+
+		var decoded Permit2Authorization
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, local.From, decoded.From)
+		require.Equal(t, local.Permitted.Token, decoded.Permitted.Token)
+		require.Equal(t, 0, local.Permitted.Amount.Cmp(decoded.Permitted.Amount))
+		require.Equal(t, local.Spender, decoded.Spender)
+		require.Equal(t, 0, local.Nonce.Cmp(decoded.Nonce))
+		require.Equal(t, 0, local.Deadline.Cmp(decoded.Deadline))
+		require.Equal(t, local.Witness.To, decoded.Witness.To)
+		require.Equal(t, 0, local.Witness.ValidAfter.Cmp(decoded.Witness.ValidAfter))
+	})
+
+	t.Run("round-trip preserves fields", func(t *testing.T) {
+		data, err := json.Marshal(local)
+		require.NoError(t, err)
+		var decoded Permit2Authorization
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Equal(t, local.From, decoded.From)
+		require.Equal(t, local.Permitted.Token, decoded.Permitted.Token)
+		require.Equal(t, 0, local.Permitted.Amount.Cmp(decoded.Permitted.Amount))
+		require.Equal(t, local.Spender, decoded.Spender)
+		require.Equal(t, 0, local.Nonce.Cmp(decoded.Nonce))
+		require.Equal(t, 0, local.Deadline.Cmp(decoded.Deadline))
+		require.Equal(t, local.Witness.To, decoded.Witness.To)
+		require.Equal(t, 0, local.Witness.ValidAfter.Cmp(decoded.Witness.ValidAfter))
+	})
+}
+
+func TestEVMPayloadUnmarshalUpstreamBytes(t *testing.T) {
+	upstream := sdk.ExactEIP3009Payload{
+		Signature: "0x" + string(make([]byte, 130)), // 65-byte placeholder signature in hex
+		Authorization: sdk.ExactEIP3009Authorization{
+			From:        "0x47322Ca28a85B12a7EA64a251Cd8b9Ea1fac037b",
+			To:          "0x1234567890123456789012345678901234567890",
+			Value:       "10000",
+			ValidAfter:  "0",
+			ValidBefore: "9999999999",
+			Nonce:       "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+		},
+	}
+	data, err := json.Marshal(upstream)
+	require.NoError(t, err)
+
+	var local EVMPayload
+	require.NoError(t, json.Unmarshal(data, &local))
+	require.NotNil(t, local.Authorization)
+	require.Equal(t, "0x47322Ca28a85B12a7EA64a251Cd8b9Ea1fac037b", local.Authorization.From.Hex())
+	require.Equal(t, int64(10000), local.Authorization.Value.Int64())
+	require.Equal(t, int64(0), local.Authorization.ValidAfter.Int64())
+	require.Equal(t, int64(9999999999), local.Authorization.ValidBefore.Int64())
+	require.Equal(t, byte(0x01), local.Authorization.Nonce[0])
+	require.Equal(t, byte(0x20), local.Authorization.Nonce[31])
+}
+
+func TestPermit2PayloadUnmarshalUpstreamBytes(t *testing.T) {
+	upstream := sdk.ExactPermit2Payload{
+		Signature: "0x" + string(make([]byte, 130)),
+		Permit2Authorization: sdk.Permit2Authorization{
+			From: "0x47322Ca28a85B12a7EA64a251Cd8b9Ea1fac037b",
+			Permitted: sdk.Permit2TokenPermissions{
+				Token:  "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+				Amount: "1000000",
+			},
+			Spender:  X402ExactPermit2ProxyAddress.Hex(),
+			Nonce:    "42",
+			Deadline: "9999999999",
+			Witness: sdk.Permit2Witness{
+				To:         "0x1234567890123456789012345678901234567890",
+				ValidAfter: "0",
+			},
+		},
+	}
+	data, err := json.Marshal(upstream)
+	require.NoError(t, err)
+
+	var local Permit2Payload
+	require.NoError(t, json.Unmarshal(data, &local))
+	require.NotNil(t, local.Permit2Authorization)
+	auth := local.Permit2Authorization
+	require.Equal(t, "0x47322Ca28a85B12a7EA64a251Cd8b9Ea1fac037b", auth.From.Hex())
+	require.Equal(t, "0x036CbD53842c5426634e7929541eC2318f3dCF7e", auth.Permitted.Token.Hex())
+	require.Equal(t, int64(1000000), auth.Permitted.Amount.Int64())
+	require.Equal(t, X402ExactPermit2ProxyAddress, auth.Spender)
+	require.Equal(t, int64(42), auth.Nonce.Int64())
+	require.Equal(t, int64(9999999999), auth.Deadline.Int64())
+	require.Equal(t, int64(0), auth.Witness.ValidAfter.Int64())
+}

--- a/types/error.go
+++ b/types/error.go
@@ -3,15 +3,18 @@ package types
 import "errors"
 
 var (
-	ErrInvalidPayloadFormat = errors.New("invalid_payload_format")
-	ErrIncompatibleScheme   = errors.New("incompatible_payload_scheme")
-	ErrNetworkMismatch      = errors.New("network_mismatch")
-	ErrInvalidNetwork       = errors.New("invalid_network")
-	ErrNetworkIDMismatch    = errors.New("network_id_mismatch")
-	ErrInvalidSignature     = errors.New("invalid_signature")
-	ErrInvalidToken         = errors.New("invalid_token")
-	ErrTokenMismatch        = errors.New("token_mismatch")
-	ErrInsufficientBalance  = errors.New("insufficient_balance")
+	ErrInvalidPayloadFormat   = errors.New("invalid_payload_format")
+	ErrIncompatibleScheme     = errors.New("incompatible_payload_scheme")
+	ErrNetworkMismatch        = errors.New("network_mismatch")
+	ErrInvalidNetwork         = errors.New("invalid_network")
+	ErrNetworkIDMismatch      = errors.New("network_id_mismatch")
+	ErrInvalidSignature       = errors.New("invalid_signature")
+	ErrInvalidSignatureFormat = errors.New("invalid_signature_format")
+	ErrInvalidToken           = errors.New("invalid_token")
+	ErrTokenMismatch          = errors.New("token_mismatch")
+	ErrInsufficientBalance    = errors.New("insufficient_balance")
+	ErrContractBindFailed     = errors.New("contract_bind_failed")
+	ErrTransactionFailed      = errors.New("transaction_failed")
 
 	// Permit2 errors
 	ErrPermit2InvalidSpender    = errors.New("permit2_invalid_spender")

--- a/types/facilitator.go
+++ b/types/facilitator.go
@@ -1,143 +1,115 @@
-// Package types declares the wire-level structures exchanged between
-// facilitator clients, resource servers, and this facilitator over HTTP.
-//
-// The structs below mirror the x402 v2 specification field-for-field. They
-// are intentionally redeclared here (rather than aliased from
-// github.com/gosuda/x402-facilitator/internal/sdk) because swaggo/swag
-// cannot resolve a Go type alias whose target has the same short name in a
-// different package and aborts `make generate-api` with a false-positive
-// recursion error.
-//
-// Drift against the upstream SDK is guarded by TestV2WireCompatibility in
-// types/facilitator_test.go: it round-trips every struct declared here
-// through the corresponding internal/sdk re-export and asserts JSON
-// equality, so any upstream field rename surfaces as a local test failure.
-//
-// Specification: https://github.com/coinbase/x402/blob/main/specs/x402-specification.md
 package types
 
-// Network is a CAIP-2 network identifier (e.g. "eip155:84532" for Base
-// Sepolia). It is a named string so handlers can distinguish a network
-// from an arbitrary string in signatures.
+// Specification: https://github.com/coinbase/x402/blob/main/specs/x402-specification.md
+//
+// These structs are redeclared locally (not aliased from internal/sdk) so
+// swaggo/swag can parse them during `make generate-api`; drift against the
+// upstream SDK is guarded by TestV2WireCompatibility.
+
+// Network is a CAIP-2 network identifier (e.g., "eip155:84532" for Base Sepolia).
 type Network string
 
-// PaymentRequirements describes what a resource server accepts for a
-// given endpoint. It is the 402 Payment Required response body.
+// PaymentRequirements defines the structure for accepted payments by the resource server.
+// This corresponds to the server's response in the 402 Payment Required flow.
 type PaymentRequirements struct {
-	// Scheme of the payment protocol to use (e.g. "exact").
+	// Scheme of the payment protocol to use (e.g., "exact")
 	Scheme string `json:"scheme"`
-	// Network in CAIP-2 format (e.g. "eip155:84532").
+	// Network in CAIP-2 format (e.g., "eip155:84532")
 	Network string `json:"network"`
-	// Asset is the token contract address (EVM) or mint (SVM) being paid.
+	// Asset is the token contract address (EVM) or mint (SVM) being paid
 	Asset string `json:"asset"`
-	// Amount required to pay for the resource in atomic units, as a
-	// decimal string. This replaces the v1 field "maxAmountRequired".
+	// Amount required to pay for the resource in atomic units, as a decimal string
 	Amount string `json:"amount"`
-	// PayTo is the address that receives the payment.
+	// Address to pay value to
 	PayTo string `json:"payTo"`
-	// MaxTimeoutSeconds is the maximum time the resource server will
-	// wait for the payment to be facilitated.
+	// Maximum time in seconds for the resource server to respond
 	MaxTimeoutSeconds int `json:"maxTimeoutSeconds"`
-	// Extra carries scheme-specific metadata (e.g. the EIP-712 domain
-	// name and version for EIP-3009).
+	// Scheme-specific metadata (e.g., EIP-712 domain name and version)
 	Extra map[string]interface{} `json:"extra,omitempty"`
 }
 
-// PaymentPayload is the body a client sends in the X-PAYMENT header. In
-// v2 the scheme and network fields live inside Accepted, not at the top
-// level, and Payload is a decoded map rather than raw JSON.
+// PaymentPayload represents the data the client sends in the X-PAYMENT header.
+// In v2 the scheme and network fields live inside Accepted, not at the top level.
 type PaymentPayload struct {
-	// X402Version is the protocol version (always 2 for v2 payloads).
+	// Version of the x402 payment protocol
 	X402Version int `json:"x402Version"`
-	// Payload is the scheme-specific payment material (e.g. an EIP-3009
-	// authorization + signature). Its shape depends on Accepted.Scheme.
+	// Scheme-specific payment material (e.g., an EIP-3009 authorization + signature)
 	Payload map[string]interface{} `json:"payload"`
-	// Accepted echoes the PaymentRequirements the client is paying
-	// against. Facilitators read scheme/network from here.
+	// The PaymentRequirements the client is paying against
 	Accepted PaymentRequirements `json:"accepted"`
-	// Resource describes the resource being paid for. Optional.
+	// Resource describes the resource being paid for (optional)
 	Resource *ResourceInfo `json:"resource,omitempty"`
-	// Extensions carries protocol extension data. Optional.
+	// Protocol extension data (optional)
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
-// ResourceInfo describes the resource being paid for. In v1 these fields
-// lived on PaymentRequirements; v2 moved them up onto PaymentPayload.
+// ResourceInfo describes the resource being paid for. In v2 these fields moved
+// out of PaymentRequirements and onto PaymentPayload.
 type ResourceInfo struct {
 	URL         string `json:"url"`
 	Description string `json:"description,omitempty"`
 	MimeType    string `json:"mimeType,omitempty"`
 }
 
-// PaymentVerifyRequest is the request body sent to POST /verify.
+// PaymentVerifyRequest is the request body sent to facilitator's /verify endpoint.
 type PaymentVerifyRequest struct {
 	PaymentPayload      PaymentPayload      `json:"paymentPayload"`
 	PaymentRequirements PaymentRequirements `json:"paymentRequirements"`
 }
 
-// PaymentVerifyResponse is the response returned from POST /verify.
+// PaymentVerifyResponse is the response returned from the /verify endpoint.
 type PaymentVerifyResponse struct {
-	// IsValid reports whether the payment payload is valid.
+	// Whether the payment payload is valid
 	IsValid bool `json:"isValid"`
-	// InvalidReason is a short machine-readable code (e.g.
-	// "insufficient_balance") when IsValid is false.
+	// Short machine-readable code (e.g., "insufficient_balance") when IsValid is false
 	InvalidReason string `json:"invalidReason,omitempty"`
-	// InvalidMessage is a human-readable explanation when IsValid is
-	// false. Clients may surface this to end users.
+	// Human-readable explanation when IsValid is false
 	InvalidMessage string `json:"invalidMessage,omitempty"`
-	// Payer is the address that signed the payment, when recoverable.
+	// Address that signed the payment, when recoverable
 	Payer string `json:"payer,omitempty"`
 }
 
-// PaymentSettleRequest is the request body sent to POST /settle.
+// PaymentSettleRequest is the request body sent to facilitator's /settle endpoint.
 type PaymentSettleRequest struct {
 	PaymentPayload      PaymentPayload      `json:"paymentPayload"`
 	PaymentRequirements PaymentRequirements `json:"paymentRequirements"`
 }
 
-// PaymentSettleResponse is the response returned from POST /settle.
+// PaymentSettleResponse is the response from the /settle endpoint.
 type PaymentSettleResponse struct {
-	// Success reports whether settlement broadcast was accepted.
+	// Whether the payment broadcast was accepted
 	Success bool `json:"success"`
-	// ErrorReason is a short machine-readable code when Success is false.
+	// Short machine-readable error code when Success is false
 	ErrorReason string `json:"errorReason,omitempty"`
-	// ErrorMessage is a human-readable explanation when Success is false.
+	// Human-readable error message when Success is false
 	ErrorMessage string `json:"errorMessage,omitempty"`
-	// Payer is the address that signed the payment, when recoverable.
+	// Address that signed the payment, when recoverable
 	Payer string `json:"payer,omitempty"`
-	// Transaction is the on-chain transaction hash of the settled payment.
-	// This replaces the v1 field "txHash".
+	// Transaction hash of the settled payment (replaces the v1 field "txHash")
 	Transaction string `json:"transaction"`
-	// Network is the CAIP-2 network the transaction was submitted to.
-	// This replaces the v1 field "networkId".
+	// Network in CAIP-2 format (replaces the v1 field "networkId")
 	Network Network `json:"network"`
 }
 
-// SupportedKind is one (scheme, network) pair this facilitator accepts.
+// SupportedKind represents a supported scheme and network pair
+// used in the /supported endpoint.
 type SupportedKind struct {
-	// X402Version is the protocol version supported for this pair.
+	// Protocol version supported for this pair
 	X402Version int `json:"x402Version"`
-	// Scheme of the payment protocol (e.g. "exact").
+	// Scheme of the payment protocol (e.g., "exact")
 	Scheme string `json:"scheme"`
-	// Network in CAIP-2 format.
+	// Network in CAIP-2 format
 	Network string `json:"network"`
-	// Extra carries scheme-specific metadata (e.g. the SVM fee payer).
+	// Scheme-specific metadata (e.g., SVM fee payer address)
 	Extra map[string]interface{} `json:"extra,omitempty"`
 }
 
-// SupportedResponse is the body returned from GET /supported. It advertises
-// every (scheme, network) pair the facilitator accepts alongside the
-// protocol extensions it understands and the addresses it may broadcast
-// settlement transactions from, grouped by CAIP-2 family pattern.
+// SupportedResponse is the response structure returned from the /supported endpoint.
 type SupportedResponse struct {
-	// Kinds lists every accepted (scheme, network) pair.
+	// Accepted (scheme, network) pairs
 	Kinds []SupportedKind `json:"kinds"`
-	// Extensions lists the x402 protocol extensions this facilitator
-	// honours. Empty when no extensions are supported.
+	// Protocol extensions this facilitator understands
 	Extensions []string `json:"extensions"`
-	// Signers maps a CAIP-2 family pattern (e.g. "eip155:*") to the
-	// addresses this facilitator may use as the sender of settlement
-	// transactions on that family. Clients use this to allowlist or
-	// audit the facilitator's on-chain footprint.
+	// CAIP-2 family pattern (e.g., "eip155:*") → fee-payer addresses
 	Signers map[string][]string `json:"signers"`
 }

--- a/types/facilitator.go
+++ b/types/facilitator.go
@@ -1,91 +1,143 @@
+// Package types declares the wire-level structures exchanged between
+// facilitator clients, resource servers, and this facilitator over HTTP.
+//
+// The structs below mirror the x402 v2 specification field-for-field. They
+// are intentionally redeclared here (rather than aliased from
+// github.com/gosuda/x402-facilitator/internal/sdk) because swaggo/swag
+// cannot resolve a Go type alias whose target has the same short name in a
+// different package and aborts `make generate-api` with a false-positive
+// recursion error.
+//
+// Drift against the upstream SDK is guarded by TestV2WireCompatibility in
+// types/facilitator_test.go: it round-trips every struct declared here
+// through the corresponding internal/sdk re-export and asserts JSON
+// equality, so any upstream field rename surfaces as a local test failure.
+//
+// Specification: https://github.com/coinbase/x402/blob/main/specs/x402-specification.md
 package types
 
-import "encoding/json"
+// Network is a CAIP-2 network identifier (e.g. "eip155:84532" for Base
+// Sepolia). It is a named string so handlers can distinguish a network
+// from an arbitrary string in signatures.
+type Network string
 
-// Specification: https://github.com/coinbase/x402/tree/main?tab=readme-ov-file#type-specifications
-
-// PaymentRequirements defines the structure for accepted payments by the resource server.
-// This corresponds to the server's response in the 402 Payment Required flow.
+// PaymentRequirements describes what a resource server accepts for a
+// given endpoint. It is the 402 Payment Required response body.
 type PaymentRequirements struct {
-	// Scheme of the payment protocol to use (e.g., "exact")
+	// Scheme of the payment protocol to use (e.g. "exact").
 	Scheme string `json:"scheme"`
-	// Network of the blockchain to send payment on (e.g., "base-sepolia")
+	// Network in CAIP-2 format (e.g. "eip155:84532").
 	Network string `json:"network"`
-	// Maximum amount required to pay for the resource in atomic units
-	MaxAmountRequired string `json:"maxAmountRequired"`
-	// URL of the resource to pay for
-	Resource string `json:"resource"`
-	// Description of the resource
-	Description string `json:"description"`
-	// MIME type of the resource response
-	MimeType string `json:"mimeType"`
-	// Address to pay value to
-	PayTo string `json:"payTo"`
-	// Maximum time in seconds for the resource server to respond
-	MaxTimeoutSeconds int `json:"maxTimeoutSeconds"`
-	// Address of the EIP-3009 compliant ERC20 contract
+	// Asset is the token contract address (EVM) or mint (SVM) being paid.
 	Asset string `json:"asset"`
-	// Output schema of the resource response (optional)
-	OutputSchema *json.RawMessage `json:"outputSchema,omitempty"`
-	// Extra information about the payment details specific to the scheme
-	Extra *json.RawMessage `json:"extra,omitempty"`
+	// Amount required to pay for the resource in atomic units, as a
+	// decimal string. This replaces the v1 field "maxAmountRequired".
+	Amount string `json:"amount"`
+	// PayTo is the address that receives the payment.
+	PayTo string `json:"payTo"`
+	// MaxTimeoutSeconds is the maximum time the resource server will
+	// wait for the payment to be facilitated.
+	MaxTimeoutSeconds int `json:"maxTimeoutSeconds"`
+	// Extra carries scheme-specific metadata (e.g. the EIP-712 domain
+	// name and version for EIP-3009).
+	Extra map[string]interface{} `json:"extra,omitempty"`
 }
 
-// PaymentPayload represents the data the client sends in the X-PAYMENT header.
+// PaymentPayload is the body a client sends in the X-PAYMENT header. In
+// v2 the scheme and network fields live inside Accepted, not at the top
+// level, and Payload is a decoded map rather than raw JSON.
 type PaymentPayload struct {
-	// Version of the x402 payment protocol
+	// X402Version is the protocol version (always 2 for v2 payloads).
 	X402Version int `json:"x402Version"`
-	// Scheme value of the accepted paymentRequirements the client is using to pay
-	Scheme string `json:"scheme"`
-	// Network ID of the accepted paymentRequirements the client is using to pay
-	Network string `json:"network"`
-	// Payload is E-dependent and may contain authorization and signature data
-	Payload json.RawMessage `json:"payload"`
+	// Payload is the scheme-specific payment material (e.g. an EIP-3009
+	// authorization + signature). Its shape depends on Accepted.Scheme.
+	Payload map[string]interface{} `json:"payload"`
+	// Accepted echoes the PaymentRequirements the client is paying
+	// against. Facilitators read scheme/network from here.
+	Accepted PaymentRequirements `json:"accepted"`
+	// Resource describes the resource being paid for. Optional.
+	Resource *ResourceInfo `json:"resource,omitempty"`
+	// Extensions carries protocol extension data. Optional.
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
-// PaymentVerifyRequest is the request body sent to facilitator's /verify endpoint.
+// ResourceInfo describes the resource being paid for. In v1 these fields
+// lived on PaymentRequirements; v2 moved them up onto PaymentPayload.
+type ResourceInfo struct {
+	URL         string `json:"url"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+// PaymentVerifyRequest is the request body sent to POST /verify.
 type PaymentVerifyRequest struct {
-	X402Version         int                 `json:"x402Version"`
-	PaymentHeader       PaymentPayload      `json:"paymentHeader"`
+	PaymentPayload      PaymentPayload      `json:"paymentPayload"`
 	PaymentRequirements PaymentRequirements `json:"paymentRequirements"`
 }
 
-// PaymentVerifyResponse is the response returned from the /verify endpoint.
+// PaymentVerifyResponse is the response returned from POST /verify.
 type PaymentVerifyResponse struct {
-	// Whether the payment payload is valid
+	// IsValid reports whether the payment payload is valid.
 	IsValid bool `json:"isValid"`
-	// Error message or reason for invalidity, if applicable
+	// InvalidReason is a short machine-readable code (e.g.
+	// "insufficient_balance") when IsValid is false.
 	InvalidReason string `json:"invalidReason,omitempty"`
-	Payer         string `json:"payer,omitempty"`
+	// InvalidMessage is a human-readable explanation when IsValid is
+	// false. Clients may surface this to end users.
+	InvalidMessage string `json:"invalidMessage,omitempty"`
+	// Payer is the address that signed the payment, when recoverable.
+	Payer string `json:"payer,omitempty"`
 }
 
-// PaymentSettleRequest is the request body sent to facilitator's /settle endpoint.
+// PaymentSettleRequest is the request body sent to POST /settle.
 type PaymentSettleRequest struct {
-	X402Version         int                 `json:"x402Version"`
-	PaymentHeader       PaymentPayload      `json:"paymentHeader"`
+	PaymentPayload      PaymentPayload      `json:"paymentPayload"`
 	PaymentRequirements PaymentRequirements `json:"paymentRequirements"`
 }
 
-// PaymentSettleResponse is the response from the /settle endpoint.
+// PaymentSettleResponse is the response returned from POST /settle.
 type PaymentSettleResponse struct {
-	// Whether the payment was successful
+	// Success reports whether settlement broadcast was accepted.
 	Success bool `json:"success"`
-	// Error message, if any
-	Error string `json:"error,omitempty"`
-	// Transaction hash of the settled payment
-	TxHash string `json:"txHash,omitempty"`
-	// Network ID where the transaction was submitted
-	NetworkId string `json:"networkId,omitempty"`
+	// ErrorReason is a short machine-readable code when Success is false.
+	ErrorReason string `json:"errorReason,omitempty"`
+	// ErrorMessage is a human-readable explanation when Success is false.
+	ErrorMessage string `json:"errorMessage,omitempty"`
+	// Payer is the address that signed the payment, when recoverable.
+	Payer string `json:"payer,omitempty"`
+	// Transaction is the on-chain transaction hash of the settled payment.
+	// This replaces the v1 field "txHash".
+	Transaction string `json:"transaction"`
+	// Network is the CAIP-2 network the transaction was submitted to.
+	// This replaces the v1 field "networkId".
+	Network Network `json:"network"`
 }
 
-// SupportedKind represents a supported scheme and network pair
-// used in the /supported endpoint.
+// SupportedKind is one (scheme, network) pair this facilitator accepts.
 type SupportedKind struct {
-	Scheme  string `json:"scheme"`
+	// X402Version is the protocol version supported for this pair.
+	X402Version int `json:"x402Version"`
+	// Scheme of the payment protocol (e.g. "exact").
+	Scheme string `json:"scheme"`
+	// Network in CAIP-2 format.
 	Network string `json:"network"`
+	// Extra carries scheme-specific metadata (e.g. the SVM fee payer).
+	Extra map[string]interface{} `json:"extra,omitempty"`
 }
 
-// SupportedResponse is the response structure returned from the /supported endpoint.
+// SupportedResponse is the body returned from GET /supported. It advertises
+// every (scheme, network) pair the facilitator accepts alongside the
+// protocol extensions it understands and the addresses it may broadcast
+// settlement transactions from, grouped by CAIP-2 family pattern.
 type SupportedResponse struct {
+	// Kinds lists every accepted (scheme, network) pair.
 	Kinds []SupportedKind `json:"kinds"`
+	// Extensions lists the x402 protocol extensions this facilitator
+	// honours. Empty when no extensions are supported.
+	Extensions []string `json:"extensions"`
+	// Signers maps a CAIP-2 family pattern (e.g. "eip155:*") to the
+	// addresses this facilitator may use as the sender of settlement
+	// transactions on that family. Clients use this to allowlist or
+	// audit the facilitator's on-chain footprint.
+	Signers map[string][]string `json:"signers"`
 }

--- a/types/facilitator_test.go
+++ b/types/facilitator_test.go
@@ -1,0 +1,142 @@
+package types_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gosuda/x402-facilitator/internal/sdk"
+	"github.com/gosuda/x402-facilitator/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestV2WireCompatibility round-trips every locally declared wire struct in
+// types/facilitator.go through the corresponding x402 v2 SDK type (via
+// internal/sdk) and asserts JSON equality. If the upstream SDK ever renames
+// a field or changes a JSON tag and go.mod is bumped, this test fails and
+// forces an explicit update of types/facilitator.go rather than letting the
+// public HTTP contract of /verify, /settle, and /supported drift silently.
+//
+// The local structs live in types/facilitator.go (rather than as aliases of
+// the SDK) because swaggo/swag cannot resolve an alias chain whose target
+// has the same short name in a different package; this test is the contract
+// that keeps those parallel declarations honest.
+func TestV2WireCompatibility(t *testing.T) {
+	t.Run("PaymentRequirements", func(t *testing.T) {
+		local := types.PaymentRequirements{
+			Scheme:            "exact",
+			Network:           "eip155:84532",
+			Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+			Amount:            "1000",
+			PayTo:             "0x1234567890123456789012345678901234567890",
+			MaxTimeoutSeconds: 300,
+			Extra: map[string]interface{}{
+				"name":    "USDC",
+				"version": "2",
+			},
+		}
+		assertWireCompat[sdk.PaymentRequirements](t, local)
+	})
+
+	t.Run("PaymentPayload", func(t *testing.T) {
+		local := types.PaymentPayload{
+			X402Version: int(types.X402VersionV2),
+			Payload: map[string]interface{}{
+				"signature": "0xabc",
+				"authorization": map[string]interface{}{
+					"from":        "0x1234567890123456789012345678901234567890",
+					"to":          "0x2345678901234567890123456789012345678901",
+					"value":       "1000",
+					"validAfter":  "0",
+					"validBefore": "9999999999",
+					"nonce":       "0x0000000000000000000000000000000000000000000000000000000000000001",
+				},
+			},
+			Accepted: types.PaymentRequirements{
+				Scheme:            "exact",
+				Network:           "eip155:84532",
+				Asset:             "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+				Amount:            "1000",
+				PayTo:             "0x2345678901234567890123456789012345678901",
+				MaxTimeoutSeconds: 300,
+			},
+			Resource: &types.ResourceInfo{
+				URL:         "https://example.com/api/data",
+				Description: "example resource",
+				MimeType:    "application/json",
+			},
+			Extensions: map[string]interface{}{
+				"eip2612GasSponsoring": map[string]interface{}{
+					"sponsor": "0x3456789012345678901234567890123456789012",
+				},
+			},
+		}
+		assertWireCompat[sdk.PaymentPayload](t, local)
+	})
+
+	t.Run("SupportedKind", func(t *testing.T) {
+		local := types.SupportedKind{
+			X402Version: int(types.X402VersionV2),
+			Scheme:      "exact",
+			Network:     "eip155:84532",
+			Extra: map[string]interface{}{
+				"feePayer": "0x1234567890123456789012345678901234567890",
+			},
+		}
+		assertWireCompat[sdk.SupportedKind](t, local)
+	})
+
+	t.Run("SupportedResponse", func(t *testing.T) {
+		local := types.SupportedResponse{
+			Kinds: []types.SupportedKind{{
+				X402Version: int(types.X402VersionV2),
+				Scheme:      "exact",
+				Network:     "eip155:84532",
+			}},
+			Extensions: []string{"eip2612GasSponsoring"},
+			Signers: map[string][]string{
+				"eip155:*": {"0x1234567890123456789012345678901234567890"},
+			},
+		}
+		assertWireCompat[sdk.SupportedResponse](t, local)
+	})
+
+	t.Run("PaymentVerifyResponse", func(t *testing.T) {
+		local := types.PaymentVerifyResponse{
+			IsValid:        false,
+			InvalidReason:  "insufficient_balance",
+			InvalidMessage: "payer balance is below the requested amount",
+			Payer:          "0x1234567890123456789012345678901234567890",
+		}
+		assertWireCompat[sdk.VerifyResponse](t, local)
+	})
+
+	t.Run("PaymentSettleResponse", func(t *testing.T) {
+		local := types.PaymentSettleResponse{
+			Success:     true,
+			Payer:       "0x1234567890123456789012345678901234567890",
+			Transaction: "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+			Network:     types.Network("eip155:84532"),
+		}
+		assertWireCompat[sdk.SettleResponse](t, local)
+	})
+}
+
+// assertWireCompat marshals local to JSON, unmarshals the bytes into the
+// upstream SDK type SDK, re-marshals, and asserts that the two JSON blobs
+// are equal. Any field rename, tag change, or added required field between
+// the local struct and the upstream SDK type surfaces as a mismatch here.
+func assertWireCompat[SDK any](t *testing.T, local any) {
+	t.Helper()
+
+	localJSON, err := json.Marshal(local)
+	require.NoError(t, err, "marshal local value")
+
+	var remote SDK
+	require.NoError(t, json.Unmarshal(localJSON, &remote), "unmarshal local JSON into SDK type")
+
+	remoteJSON, err := json.Marshal(remote)
+	require.NoError(t, err, "marshal SDK value")
+
+	require.JSONEq(t, string(localJSON), string(remoteJSON),
+		"wire drift between local %T and its x402 SDK counterpart", local)
+}

--- a/types/facilitator_test.go
+++ b/types/facilitator_test.go
@@ -9,17 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestV2WireCompatibility round-trips every locally declared wire struct in
-// types/facilitator.go through the corresponding x402 v2 SDK type (via
-// internal/sdk) and asserts JSON equality. If the upstream SDK ever renames
-// a field or changes a JSON tag and go.mod is bumped, this test fails and
-// forces an explicit update of types/facilitator.go rather than letting the
-// public HTTP contract of /verify, /settle, and /supported drift silently.
-//
-// The local structs live in types/facilitator.go (rather than as aliases of
-// the SDK) because swaggo/swag cannot resolve an alias chain whose target
-// has the same short name in a different package; this test is the contract
-// that keeps those parallel declarations honest.
+// TestV2WireCompatibility round-trips every local wire struct through the
+// corresponding internal/sdk re-export and asserts JSON equality, so any
+// upstream field rename surfaces as a local test failure rather than
+// silently breaking /verify, /settle, and /supported.
 func TestV2WireCompatibility(t *testing.T) {
 	t.Run("PaymentRequirements", func(t *testing.T) {
 		local := types.PaymentRequirements{
@@ -121,10 +114,8 @@ func TestV2WireCompatibility(t *testing.T) {
 	})
 }
 
-// assertWireCompat marshals local to JSON, unmarshals the bytes into the
-// upstream SDK type SDK, re-marshals, and asserts that the two JSON blobs
-// are equal. Any field rename, tag change, or added required field between
-// the local struct and the upstream SDK type surfaces as a mismatch here.
+// assertWireCompat round-trips local through the SDK type and asserts JSON
+// equality, catching field renames and tag changes across the boundary.
 func assertWireCompat[SDK any](t *testing.T, local any) {
 	t.Helper()
 

--- a/types/scheme.go
+++ b/types/scheme.go
@@ -3,16 +3,17 @@ package types
 type Scheme string
 
 const (
-	EVM    Scheme = "evm"
-	Solana Scheme = "solana"
-	Sui    Scheme = "sui"
-	Tron   Scheme = "tron"
+	// Exact is the x402 v2 "exact amount" payment scheme. It is currently
+	// the only scheme this facilitator supports; other schemes (e.g. the
+	// forthcoming "upto") can be added alongside it when they land.
+	Exact Scheme = "exact"
 )
 
 type X402Version int
 
 const (
 	X402VersionV1 X402Version = 1
+	X402VersionV2 X402Version = 2
 )
 
 type Signer func(digest []byte) (signature []byte, err error)


### PR DESCRIPTION
## Summary

Upgrades this facilitator to the x402 v2 wire format so any v2 client built on `github.com/coinbase/x402/go` can drive `/verify`, `/settle`, and `/supported` end-to-end against it. Verified with a real Base Sepolia USDC transfer — see **Verification** below.

## What changes

### Type layer (v2 wire shape)
- `types/facilitator.go` rewritten as concrete v2 structs mirroring the upstream SDK field-for-field: `PaymentPayload` with nested `Accepted`, `PaymentRequirements.Amount` (renamed from `MaxAmountRequired`), `PaymentSettleResponse.{Transaction, Network, ErrorReason, ErrorMessage}` (replacing `TxHash` / `NetworkId` / `Error`), `PaymentVerifyResponse.InvalidMessage`, `SupportedResponse.{Kinds, Extensions, Signers}`, `SupportedKind.{X402Version, Extra}`, and a CAIP-2 `Network` named string type.
- `/verify` and `/settle` request bodies now use `paymentPayload` (not the v1 `paymentHeader`).
- `types/scheme.go` drops the per-chain `EVM/Solana/Sui/Tron` constants and keeps only `Exact`; adds `X402VersionV2`.
- Types are declared concretely (not aliased from `internal/sdk`) because `swaggo/swag` can't resolve alias chains whose target has the same short name in a different package.

### Drift protection
- `types/facilitator_test.go` (new) round-trips every local wire struct through the corresponding `internal/sdk` re-export with `require.JSONEq`. Any upstream field rename surfaces as a local test failure rather than a silent HTTP-contract break.
- `scheme/evm/types_test.go` (new) extends the guard to the inner EIP-3009 / Permit2 payload shapes, asserting bidirectional byte compatibility with `sdk.ExactEIP3009Authorization` and `sdk.Permit2Authorization`.

### Facilitator interface & network routing
- `facilitator/iface.go`: `Supported() *types.SupportedResponse` consolidates discovery into one interface method — preserving the repo's existing 1:1 HTTP-endpoint-to-method pattern. `NewFacilitator` routes by CAIP-2 network prefix (`eip155:`, `solana:`, `sui:`, `tron:`).
- `facilitator/evm.go` `Supported()` advertises the configured chain and surfaces the fee-payer address under `Signers["eip155:*"]`.
- `facilitator/{solana,sui,tron}.go` `Supported()` return `nil` — their Verify/Settle are still stubs, so honest gating from discovery until each chain is implemented.

### EIP-3009 / Permit2 verify & settle hardening
Surfaced during x402-demo integration testing on Base Sepolia:

- `scheme/evm/chaincfg.go` `GetDomainConfig` now resolves tokens by **contract address** in addition to symbol, matching the v2 spec's `asset` field. Without this, every v2 request failed with `ErrTokenMismatch` before touching the chain.
- `scheme/evm/types.go` adds custom `MarshalJSON` / `UnmarshalJSON` on `Authorization`, `Permit2Authorization`, `Permit2TokenPermissions`, and `Permit2Witness` so internal `*big.Int` / `[32]byte` fields translate transparently to and from the v2 wire format (decimal strings + hex nonces). Signing and hashing code are untouched — they read fields directly.
- `facilitator/evm.go`:
  - Nil-guard on `evmPayload.Authorization` after unmarshal in `verifyEIP3009` (mirrors the existing Permit2 guard). Fixes a `/verify` empty-body panic.
  - Every early-return in `settleEIP3009` / `settlePermit2` populates `Network` and `Payer` (extracted once right after unmarshal) so clients can debug failures.
  - Contract-bind, signature-parse, and transaction-submit failures now return **HTTP 200 with a structured `errorReason` + `errorMessage`** instead of HTTP 500, matching upstream convention.
  - Fixes a latent bug: `NetworkId: fmt.Sprintf("%d", networkID)` was formatting a `*big.Int` pointer address, not the chain id. The v2 `Network` field carries the CAIP-2 string directly.
- `types/error.go` adds `ErrInvalidSignatureFormat`, `ErrContractBindFailed`, `ErrTransactionFailed` sentinels.

### HTTP layer, CLI, generated artifacts
- `api/server.go` + `api/client/client.go` speak the `paymentPayload` request key, and the `/supported` handler is a thin pass-through over `facilitator.Supported()`.
- `cmd/client/main.go` builds v2 `PaymentPayload` (nested `Accepted`, map-based `Payload`, `X402VersionV2`) and defaults to `--scheme exact` / `--network eip155:84532`.
- `internal/sdk/sdk.go` re-exports `ResourceInfo` and `SupportedResponse` so the drift guard covers the full wire surface through the existing facade.
- `api/swagger/*` regenerated via `make generate-api`. Uses `paymentPayload`, `amount`, `transaction`, `network`, `kinds`, `extensions`, `signers`, `x402Version`.
- `README.md` replaces the flat "Support Schemes" table with a `scheme × network-family` matrix and documents CAIP-2 identifiers with concrete `eip155` examples.
- `config.toml` updates defaults (`scheme = "exact"`, `network = "eip155:84532"`) and adds per-field comments.

## v2 spec compliance (before → after)

| Upstream v2 field / shape | Before | After |
|---|---|---|
| `PaymentPayload.accepted.{scheme, network}` nested | top-level | nested |
| `PaymentPayload.payload` | `json.RawMessage` | `map[string]interface{}` |
| `PaymentRequirements.amount` | `maxAmountRequired` | `amount` |
| `PaymentSettleResponse.transaction` | `txHash` | `transaction` |
| `PaymentSettleResponse.network` | `networkId` (pointer address) | CAIP-2 `Network` |
| `PaymentSettleResponse.{errorReason, errorMessage}` | single `error` | split |
| `PaymentVerifyResponse.invalidMessage` | absent | present |
| `/verify`, `/settle` request body key | `paymentHeader` | `paymentPayload` |
| `SupportedResponse` | `{kinds}` only | `{kinds, extensions, signers}` |
| `SupportedKind.{x402Version, extra}` | absent | present |
| `asset` as contract address | symbol-only lookup failed | accepts both symbol and address |
| EIP-3009 / Permit2 numeric fields on wire | JSON numbers + base64 nonce | decimal strings + hex nonce |
| Unimplemented SVM / Sui / Tron in `/supported` | falsely advertised | gated |

## Verification

### Unit & drift
- `go build ./...` and `go vet ./...` green
- `go test -count=1 ./types/... ./internal/sdk/... ./scheme/evm/...` — **all passing** (drift guards + new EIP-3009 / Permit2 wire compat tests + chaincfg address-resolution tests)
- **Every commit builds and vets independently** (bisect-safe)
- Docker parity: `CGO_ENABLED=0 go build -o facilitator ./cmd/facilitator` reproduces the Dockerfile's exact build

### End-to-end (Base Sepolia)

Ran the Docker-built facilitator against the x402-demo resource server and client. The signed EIP-3009 authorization was verified, settled, and broadcast on-chain.

**Real USDC transfer:** <https://sepolia.basescan.org/tx/0x9801a9652077513aa44986549e3e0ff952a3f12fe5aff398268764e2e68e8d10>

`/settle` response:
```json
{
  "success": true,
  "transaction": "0x9801a9652077513aa44986549e3e0ff952a3f12fe5aff398268764e2e68e8d10",
  "network": "eip155:84532",
  "payer": "0x47322Ca28a85B12a7EA64a251Cd8b9Ea1fac037b"
}
```

`/supported` response:
```json
{
  "kinds": [{"x402Version": 2, "scheme": "exact", "network": "eip155:84532"}],
  "extensions": [],
  "signers": {"eip155:*": ["0x23fbdE5A14dFB508502f5A2622f66c0D3B0ab37A"]}
}
```